### PR TITLE
Documente et active l'emploi de l'API Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 1.1.2 [#11](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/11)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france_fiscalite_miniere/__init__.py`.
+* Détails :
+  - Corrige le démarrage de l'API Web OpenFisca.
+  - Ajoute et documente les commandes d'installation, de test pour le développement et d'exécution de l'API Web.
+
 ### 1.1.1 [#9](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/9)
 
 * Évolution du système socio-fiscal.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+
+API_PORT=5000
+
 all: test
 
 uninstall:
@@ -15,6 +18,9 @@ install: deps
 	@# `make install` installs the editable version of OpenFisca-France.
 	@# This allows contributors to test as they code.
 	pip install --editable .[dev] --upgrade
+
+install-api: deps
+	pip install openfisca-core[web-api]
 
 build: clean deps
 	@# Install OpenFisca-France-Fiscalite-Miniere for deployment and publishing.
@@ -37,3 +43,6 @@ check-types:
 
 test: clean check-syntax-errors check-style check-types
 	openfisca test openfisca_france_fiscalite_miniere/tests --country-package openfisca_france_fiscalite_miniere
+
+serve:
+	openfisca serve --country-package openfisca_france_fiscalite_miniere -p ${API_PORT}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ install: deps
 	@# This allows contributors to test as they code.
 	pip install --editable .[dev] --upgrade
 
+install-prod:
+	pip install openfisca-france-fiscalite-miniere
+
 install-api: deps
 	pip install openfisca-core[web-api]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,41 @@ Ce paquet requiert [Python 3.7](https://www.python.org/downloads/release/python-
 
 Il est recommandé d'utiliser un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) (_virtualenv_) avec un gestionnaire de _virtualenv_ tel que [Pew](https://github.com/berdario/pew).
 
+### Installation pour le développement
+
+Afin d'installer `OpenFisca-France-Fiscalite-Miniere`, il est nécessaire d'indexer son code et d'installer ses dépendances.
+
+> Si vous disposez d'un environnement virtuel, activez-le à cette étape.
+
+Afin d'installer l'ensemble des librairies nécessaires au développement, dans un terminal, exécuter le commande suivante :
+
+```sh
+make install
+```
+
+Pour en savoir plus sur cette commande, consulter le tag `install` et ses dépendances dans le fichier `./Makefile`.
+
+## Tester et vérifier une installation
+
+Les tests du module `OpenFisca-France-Fiscalite-Miniere` peuvent être vérifiés par la commande suivante :
+
+```sh
+make test
+```
+
+Pour en savoir plus sur cette commande, consulter le tag `test` du fichier `./Makefile`.
+
+Le résultat de cette commande doit afficher la ligne suivante :
+
+```sh
+...
+Success: no issues found in X source files
+...
+============================== XX passed in X.XXs ==============================
+```
+
+🎉 Félicitations, `OpenFisca-France-Fiscalite-Miniere` est prêt à être utilisé !
+
 ## Servir l'API Web
 
 Afin d'installer les librairies spécifiques à l'API Web, exécuter cette commande :

--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ Ce paquet requiert [Python 3.7](https://www.python.org/downloads/release/python-
 
 Il est recommandé d'utiliser un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) (_virtualenv_) avec un gestionnaire de _virtualenv_ tel que [Pew](https://github.com/berdario/pew).
 
+## Servir l'API Web
+
+Afin d'installer les librairies spécifiques à l'API Web, exécuter cette commande :
+
+```sh
+make install-api
+```
+
+Puis, démarrer l'API Web avec cette commande :
+
+```sh
+make serve
+```
+
+Un port par défaut est défini dans le `Makefile` (port `5000`).
+
+Pour en savoir plus sur la commande `openfisca serve` sous-jascente et ses options, consultez la [documentation de référence](https://openfisca.org/doc/openfisca-python-api/openfisca_serve.html).
+
+### Envoyer une première requête à l'API Web
+
+Un exemple de requête simple est donné dans ce fichier :
+`./openfisca_france_fiscalite_miniere/examples/societe.json`
+
+Pour transmettre la requête à l'API Web démarrée, dans un autre terminal, aller dans le répertoire du fichier JSON et envoyer la requête avec les commandes suivantes :
+
+```
+cd ./openfisca_france_fiscalite_miniere/examples
+curl -X POST http://localhost:5000/calculate -H 'Content-Type: application/json' -d @societe.json
+```
+
 ## Lexique
 
 * RCM = Redevance Communale des Mines

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # OpenFisca France — Fiscalité Minière
 
-Système de fiscalité minière française pour OpenFisca
+Système de fiscalité minière française modélisé avec OpenFisca
 
-## Feuille de route
+## Installation
 
-![roadmap](https://user-images.githubusercontent.com/329236/74548103-845d3b00-4f4d-11ea-9b99-a56b08c1f932.jpg)
+Ce paquet requiert [Python 3.7](https://www.python.org/downloads/release/python-370/) et [pip](https://pip.pypa.io/en/stable/installing/).
+
+Il est recommandé d'utiliser un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) (_virtualenv_) avec un gestionnaire de _virtualenv_ tel que [Pew](https://github.com/berdario/pew).
 
 ## Lexique
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ make install
 
 Pour en savoir plus sur cette commande, consulter le tag `install` et ses dépendances dans le fichier `./Makefile`.
 
+### Installation pour la production
+
+```sh
+make install-prod
+```
+
 ## Tester et vérifier une installation
 
 Les tests du module `OpenFisca-France-Fiscalite-Miniere` peuvent être vérifiés par la commande suivante :

--- a/openfisca_france_fiscalite_miniere/__init__.py
+++ b/openfisca_france_fiscalite_miniere/__init__.py
@@ -13,7 +13,7 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
         self.add_variables_from_directory(os.path.join(COUNTRY_DIR, 'variables'))
         self.load_parameters(os.path.join(COUNTRY_DIR, 'parameters'))
         self.open_api_config = {
-            "variable_example": "redevance_communale_des_mines",
+            "variable_example": "redevance_communale_des_mines_aurifere_kg",
             "parameter_example": "redevances.communales.aurifere",
             "simulation_example": examples.societe,
             }

--- a/openfisca_france_fiscalite_miniere/examples/societe.json
+++ b/openfisca_france_fiscalite_miniere/examples/societe.json
@@ -1,15 +1,11 @@
 {
-    "sociétés": {
-        "Mau Corp.": {
-            "nature": {
-                "2019": "aurifere",
-                "2018": "aurifere"
-            },
-            "quantite": {
+    "societes": {
+        "un_titre_exemple": {
+            "quantite_aurifere_kg": {
                 "2019": 1000,
                 "2018": 1000
             },
-            "redevance_communale_des_mines": {
+            "redevance_communale_des_mines_aurifere_kg": {
                 "2020": null,
                 "2019": null
             }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="1.1.1",
+    version="1.1.2",
     author="OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france_fiscalite_miniere/__init__.py`.
* Détails :
  - Corrige le démarrage de l'API Web OpenFisca.
  - Ajoute et documente les commandes d'installation, de test pour le développement et d'exécution de l'API Web.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable) : active l'API web pour la 1ère fois.
- Corrigent ou améliorent un calcul déjà existant : corrige l'initialisation de l'API web.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README) : complète Makefile et README.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
