### PR TITLE
Ajoute la proratisation des RDCM et taxe aurifère à la surface communale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.2.0
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir d 01/01/2020.
+* Zones impactées : 
+  - `variables/redevances.py`
+  - `variables/taxes.py`
+* Détails :
+  - Ajoute les input variables `surface_communale` et `surface_totale`.
+  - Ajoute les formules 2020 pour les RDCM aurifères et la taxe sur l'or en Guyane.
+    * Proratise les montants de redevances et taxe à la surface d'emprise sur la commune.
+  - Cette version représente le code du modèle employé pour la production de matrices fin 2020 (précisément en commit bdcdb7796e4a0f867fbf9ac498edc9b07b7f3c69).
+
 ### 1.1.3
 
 * Correction d'un crash et amélioration technique.

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
@@ -1,4 +1,5 @@
-description: minerais aurifères (kilogramme d'or contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais aurifères (par kilogramme d'or contenu)
 metadata:
   unit: currency-EUR
 

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
@@ -1,18 +1,3 @@
-- name: "Minerais aurifères (par kilogramme d'or contenu)"
-  input:
-    quantite_aurifere_kg:
-      2018: 100
-      2017: 100
-  output:
-    redevance_communale_des_mines_aurifere_kg:
-      2019: 14970
-      2018: 14530
-    redevance_departementale_des_mines_aurifere_kg:
-      2019: 2990
-      2018: 2900
-    # redevance_totale_des_mines_aurifere_kg:
-    #   2019: 17960
-    #   2018: 17430
 
 # - name: "Minerais d'uranium (par centaine de kilogrammes d'uranium contenu)"
 #   input:

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
@@ -1,4 +1,5 @@
-- name: "Minerais aurifères (par kilogramme d'or contenu)"
+- name: RCM et RDM des minerais aurifères en 2018 et 2019 par kilogramme d'or contenu \
+  (pré-proratisation à la surface de 2020)
   input:
     quantite_aurifere_kg:
       2018: 100
@@ -10,6 +11,6 @@
     redevance_departementale_des_mines_aurifere_kg:
       2019: 2990
       2018: 2900
-    # redevance_totale_des_mines_aurifere_kg:
-    #   2019: 17960
-    #   2018: 17430
+    redevance_totale_des_mines_aurifere_kg:
+      2019: 14970 + 2990
+      2018: 14530 + 2900

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
@@ -1,5 +1,5 @@
 - name: RCM et RDM des minerais aurifères en 2018 et 2019 par kilogramme d'or contenu \
-  (pré-proratisation à la surface de 2020)
+    (pré-proratisation à la surface de 2020)
   input:
     quantite_aurifere_kg:
       2018: 100
@@ -14,3 +14,18 @@
     redevance_totale_des_mines_aurifere_kg:
       2019: 14970 + 2990
       2018: 14530 + 2900
+
+- name: RCM et RDM des minerais aurifères en 2020 suite proratisation à la surface communale
+  period: 2020
+  absolute_error_margin: 0.01
+  input:
+    surface_communale: 
+      2019: [0.1000, 10.0000] # /surface_totale = [0,0099, 0.9901]
+    surface_totale: 
+      2019: [10.1000, 10.1000]
+    quantite_aurifere_kg: 
+      2019: [2.000, 20.000]
+  output:
+    redevance_communale_des_mines_aurifere_kg: [3.0413, 3041.5872]  # tarif = 153.60
+    redevance_departementale_des_mines_aurifere_kg: [0.6079, 607.9214]  # tarif = 30.70
+    redevance_totale_des_mines_aurifere_kg: [3.6492, 3649.5086]

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
@@ -1,0 +1,15 @@
+- name: "Minerais aurifères (par kilogramme d'or contenu)"
+  input:
+    quantite_aurifere_kg:
+      2018: 100
+      2017: 100
+  output:
+    redevance_communale_des_mines_aurifere_kg:
+      2019: 14970
+      2018: 14530
+    redevance_departementale_des_mines_aurifere_kg:
+      2019: 2990
+      2018: 2900
+    # redevance_totale_des_mines_aurifere_kg:
+    #   2019: 17960
+    #   2018: 17430

--- a/openfisca_france_fiscalite_miniere/tests/test_taxes.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_taxes.yaml
@@ -71,3 +71,25 @@
       2019: 5000.0
     taxe_guyane:
       2019: 12261.5
+
+- name: "Taxe perçue pour la région de Guyane en 2020 suite proratisation à la surface communale - \
+    Déduction des investissements <= 45% de la taxe et > 5 000 €"
+  absolute_error_margin: 0.002
+  input:
+    categorie:
+      2019: pme
+    quantite_aurifere_kg:
+      2019: 50
+    investissement:
+      2019: 7500.0
+    surface_communale:
+      2019: 1
+    surface_totale:
+      2019: 10
+  output:
+    taxe_guyane_brute:
+      2020: 400.35 * 50 * 1 / 10  # tarif pme = 400.35
+    taxe_guyane_deduction:
+      2020: 2001.75 * 0.45 * 1 / 10  # taux déduction = 0.45
+    taxe_guyane:
+      2020: 2001.75 - 90.08

--- a/openfisca_france_fiscalite_miniere/variables/redevances.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances.py
@@ -119,7 +119,15 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
         surface_communale = societes("surface_communale", annee_production)
         surface_totale = societes("surface_totale", annee_production)
 
-        return numpy.round((quantites * tarif) * surface_communale / surface_totale , decimals = 2)
+        redevance_nulle = numpy.zeros(len(surface_communale))
+        redevance = numpy.divide(
+            (quantites * tarif) * surface_communale,
+            surface_totale,
+            out = redevance_nulle,
+            where = (surface_totale != 0)
+            )
+
+        return numpy.round(redevance, decimals = 2)
 
 
 class redevance_communale_des_mines_sel_abattage_kt(Variable):

--- a/openfisca_france_fiscalite_miniere/variables/redevances.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances.py
@@ -68,7 +68,7 @@ class redevance_communale_des_mines_aurifere_kg(Variable):
     label = "Redevance communale des mines pour le minerais aurifères"
     reference = [
         # répartition
-        "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000030695303/2015-06-06",  # noqa: E501 
+        "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000030695303/2015-06-06",  # noqa: E501
         # tarification
         "https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042160076/2020-07-25",  # noqa: E501
         "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006293413/1987-08-09"  # noqa: E501
@@ -76,7 +76,8 @@ class redevance_communale_des_mines_aurifere_kg(Variable):
     definition_period = YEAR
     documentation = '''
     Dite RCM pour l'or.
-    Un arrondi est effectué dans la formule car, par exemple, l'article 1519 de 2020 indique :
+    Un arrondi est effectué dans la formule car, par exemple,
+    l'article 1519 de 2020 indique :
     "Les tarifs sont arrondis au dizième d'euro le plus proche."
     '''
 
@@ -90,7 +91,10 @@ class redevance_communale_des_mines_aurifere_kg(Variable):
         surface_communale = societes("surface_communale", annee_production)
         surface_totale = societes("surface_totale", annee_production)
 
-        return numpy.round((quantites * taux) * surface_communale / surface_totale , decimals = 2)
+        return numpy.round(
+            (quantites * taux) * surface_communale / surface_totale,
+            decimals = 2
+            )
 
     def formula(societes, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
@@ -115,7 +119,8 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
         tarif = parameters(period).redevances.departementales.aurifere
         quantites = societes("quantite_aurifere_kg", annee_production)
 
-        # proratisation à la surface pour l'entité article (TODO spécifique à la Guyane ?)
+        # proratisation à la surface pour l'entité article
+        # TODO spécifique à la Guyane ?
         surface_communale = societes("surface_communale", annee_production)
         surface_totale = societes("surface_totale", annee_production)
 

--- a/openfisca_france_fiscalite_miniere/variables/redevances.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances.py
@@ -115,7 +115,11 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
         tarif = parameters(period).redevances.departementales.aurifere
         quantites = societes("quantite_aurifere_kg", annee_production)
 
-        return numpy.round(quantites * tarif, decimals = 2)
+        # proratisation à la surface pour l'entité article (TODO spécifique à la Guyane ?)
+        surface_communale = societes("surface_communale", annee_production)
+        surface_totale = societes("surface_totale", annee_production)
+
+        return numpy.round((quantites * tarif) * surface_communale / surface_totale , decimals = 2)
 
 
 class redevance_communale_des_mines_sel_abattage_kt(Variable):

--- a/openfisca_france_fiscalite_miniere/variables/redevances.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances.py
@@ -78,10 +78,10 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
 
     def formula(societes, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
-        taux = parameters(period).redevances.departementales.aurifere
+        tarif = parameters(period).redevances.departementales.aurifere
         quantites = societes("quantite_aurifere_kg", annee_production)
 
-        return numpy.round(quantites * taux, decimals = 2)
+        return numpy.round(quantites * tarif, decimals = 2)
 
 
 class redevance_communale_des_mines_sel_abattage_kt(Variable):

--- a/openfisca_france_fiscalite_miniere/variables/redevances.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances.py
@@ -110,7 +110,7 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
     ]
     definition_period = YEAR
 
-    def formula(societes, period, parameters) -> numpy.ndarray:
+    def formula_2020_01(societes, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
         tarif = parameters(period).redevances.departementales.aurifere
         quantites = societes("quantite_aurifere_kg", annee_production)
@@ -128,6 +128,13 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
             )
 
         return numpy.round(redevance, decimals = 2)
+
+    def formula(societes, period, parameters) -> numpy.ndarray:
+        annee_production = period.last_year
+        taux = parameters(period).redevances.departementales.aurifere
+        quantites = societes("quantite_aurifere_kg", annee_production)
+
+        return numpy.round(quantites * taux, decimals = 2)
 
 
 class redevance_communale_des_mines_sel_abattage_kt(Variable):

--- a/openfisca_france_fiscalite_miniere/variables/taxes.py
+++ b/openfisca_france_fiscalite_miniere/variables/taxes.py
@@ -46,7 +46,11 @@ class taxe_guyane_brute(Variable):
         tarifs = (params.categories[categorie.name] for categorie in categories)
         tarifs = numpy.fromiter(tarifs, dtype = float)
 
-        return round_(quantites * tarifs, decimals = 2)
+        # proratisation à la surface pour l'entité article
+        surface_communale = societes("surface_communale", annee_production)
+        surface_totale = societes("surface_totale", annee_production)
+
+        return round_((quantites * tarifs) * surface_communale / surface_totale , decimals = 2)
 
 
 class taxe_guyane_deduction(Variable):
@@ -64,13 +68,18 @@ class taxe_guyane_deduction(Variable):
         taux_deduction = params.deductions.taux
         montant_deduction_max = params.deductions.montant
 
-        return round_(
+        # proratisation à la surface pour l'entité article
+        surface_communale = societes("surface_communale", annee_production)
+        surface_totale = societes("surface_totale", annee_production)
+
+        deduction_toutes_communes = round_(
             min_(
                 montant_deduction_max,
                 min_(investissements, taxes_brutes * taux_deduction),
                 ),
             decimals = 2,
             )
+        return round_(deduction_toutes_communes * surface_communale / surface_totale , decimals = 2)
 
 
 class taxe_guyane(Variable):

--- a/openfisca_france_fiscalite_miniere/variables/taxes.py
+++ b/openfisca_france_fiscalite_miniere/variables/taxes.py
@@ -50,7 +50,10 @@ class taxe_guyane_brute(Variable):
         surface_communale = societes("surface_communale", annee_production)
         surface_totale = societes("surface_totale", annee_production)
 
-        return round_((quantites * tarifs) * surface_communale / surface_totale , decimals = 2)
+        return round_(
+            (quantites * tarifs) * surface_communale / surface_totale,
+            decimals = 2
+            )
 
     def formula(societes, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
@@ -89,7 +92,10 @@ class taxe_guyane_deduction(Variable):
                 ),
             decimals = 2,
             )
-        return round_(deduction_toutes_communes * surface_communale / surface_totale , decimals = 2)
+        return round_(
+            deduction_toutes_communes * surface_communale / surface_totale,
+            decimals = 2
+            )
 
     def formula(societes, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
@@ -101,11 +107,12 @@ class taxe_guyane_deduction(Variable):
 
         return round_(
             min_(
-                 montant_deduction_max,
-                 min_(investissements, taxes_brutes * taux_deduction),
-                 ),
-             decimals = 2,
+                montant_deduction_max,
+                min_(investissements, taxes_brutes * taux_deduction),
+                ),
+            decimals = 2,
             )
+
 
 class taxe_guyane(Variable):
     value_type = float

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="1.1.3",
+    version="1.2.0",
     author="OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir d 01/01/2020.
* Zones impactées : 
  - `variables/redevances.py`
  - `variables/taxes.py`
* Détails :
  - Ajoute les input variables `surface_communale` et `surface_totale`.
  - Ajoute les formules 2020 pour les RDCM aurifères et la taxe sur l'or en Guyane.
    * Proratise les montants de redevances et taxe à la surface d'emprise sur la commune.
  - Cette version représente le code du modèle employé pour la production de matrices fin 2020 (précisément en commit bdcdb7796e4a0f867fbf9ac498edc9b07b7f3c69).

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France — Fiscalité Minière (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
