### PR TITLE
Revalorise les tarifs RDM pour 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 1.3.2 [#18](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/18)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2021.
+* Zones impactées : 
+  - `parameters/redevances/departementales/*`
+  - `parameters/redevances/communales/*`
+* Détails :
+  - Revalorise les tarifs 2021 de la redevance départementale des mines (RDM).
+  - Couvre tout l'[article 1587 II](https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/).
+
 ### 1.3.1 [#16](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/16)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel_mer.yaml
@@ -2,7 +2,7 @@ description: Gaz naturel en mer (par 100 000 m3  extraits à 1 bar et 15°C)
 metadata:
   unit: currency-EUR
 documentation: |
-  Non revalorisé en 2020.
+  Non revalorisé en 2020 et 2021.
 
 values:
   2017-01-01:

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel_mer.yaml
@@ -1,8 +1,6 @@
 description: Gaz naturel en mer (par 100 000 m3  extraits à 1 bar et 15°C)
 metadata:
   unit: currency-EUR
-documentation: |
-  Non revalorisé en 2020 et 2021.
 
 values:
   2017-01-01:
@@ -16,4 +14,7 @@ values:
   2019-01-01:
     value: 25.3
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-01-01
+      reference: 
+        2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-01-01
+        2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-07-25
+        2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut_mer.yaml
@@ -2,7 +2,7 @@ description: Pétrole brut en mer (par centaine de tonnes nettes extraites)
 metadata:
   unit: currency-EUR
 documentation: |
-  Non revalorisé en 2020.
+  Non revalorisé en 2020 et 2021.
 
 values:
   2017-01-01:

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut_mer.yaml
@@ -1,8 +1,6 @@
 description: Pétrole brut en mer (par centaine de tonnes nettes extraites)
 metadata:
   unit: currency-EUR
-documentation: |
-  Non revalorisé en 2020 et 2021.
 
 values:
   2017-01-01:
@@ -16,4 +14,7 @@ values:
   2019-01-01:
     value: 86.1
     metadata:
-      reference: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-01-01
+      reference: 
+        2019-01-01: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-01-01
+        2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-07-25
+        2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/antimoine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/antimoine.yaml
@@ -1,4 +1,5 @@
-description: minerais d'antimoine (tonne d'antimoine contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais d'antimoine (tonne d'antimoine contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 2.80
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 3.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/argentifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/argentifere.yaml
@@ -1,4 +1,5 @@
-description: minerais argentifères (quintal d'argent contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais argentifères (quintal d'argent contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 49.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 53.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/arsenic.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/arsenic.yaml
@@ -1,4 +1,5 @@
-description: minerais d'arsenic (millier de tonnes d'arsenic contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais d'arsenic (millier de tonnes d'arsenic contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 137.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 148.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
@@ -20,3 +20,7 @@ values:
     value: 30.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 33.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bauxite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bauxite.yaml
@@ -1,4 +1,5 @@
-description: bauxite (millier de tonnes nettes livrées )
+description: Montant du tarif de la redevance départementale des mines
+  pour la bauxite (millier de tonnes nettes livrées )
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 117.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 127.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bismuth.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bismuth.yaml
@@ -1,4 +1,5 @@
-description: minerais de bismuth (tonne de bismuth contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de bismuth (tonne de bismuth contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 12.00
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 13.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_distillation.yaml
@@ -1,4 +1,6 @@
-description: schistes carbobitumineux et schistes bitumineux (à traiter par distillation pour en extraire des huiles et des essences) (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour les schistes carbobitumineux et schistes bitumineux \
+  à traiter par distillation pour en extraire des huiles et des essences (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +21,7 @@ values:
     value: 10.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 11.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_non_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_non_distillation.yaml
@@ -1,4 +1,6 @@
-description: calcaires et grès bitumineux ou asphaltiques (non destinés à la distillation pour production d'huiles ou d'essences) (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour les calcaires et grès bitumineux ou asphaltiques \
+  non destinés à la distillation pour production d'huiles ou d'essences (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +21,7 @@ values:
     value: 300.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 325.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/butane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/butane.yaml
@@ -1,4 +1,5 @@
-description: butane (tonne nette livrée)
+description: Montant du tarif de la redevance départementale des mines
+  pour le butane (tonne nette livrée)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 6.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 7.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/charbon.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/charbon.yaml
@@ -1,4 +1,5 @@
-description: charbon (centaine de tonnes nettes extraites)
+description: Montant du tarif de la redevance départementale des mines
+  pour le charbon (centaine de tonnes nettes extraites)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 113.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 123.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/cuivre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/cuivre.yaml
@@ -1,4 +1,5 @@
-description: minerais de cuivre (tonne de cuivre contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de cuivre (tonne de cuivre contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 4.00
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 4.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/degazolinage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/degazolinage.yaml
@@ -1,4 +1,5 @@
-description: essence de dégazolinage (tonne nette livrée)
+description: Montant du tarif de la redevance départementale des mines
+  pour l'essence de dégazolinage (tonne nette livrée)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 6.00
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 6.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/etain.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/etain.yaml
@@ -1,4 +1,5 @@
-description: minerais d'étain (tonne d'étain contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais d'étain (tonne d'étain contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 24.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 26.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer.yaml
@@ -1,4 +1,5 @@
-description: minerais de fer (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de fer (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 72.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 78.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer_pyrite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer_pyrite.yaml
@@ -1,4 +1,5 @@
-description: pyrite de fer (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour la pyrite de fer (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 102.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 111.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fluorine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fluorine.yaml
@@ -1,4 +1,5 @@
-description: fluorine (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour la fluorine (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 155.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 168.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_carbonique.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_carbonique.yaml
@@ -1,4 +1,5 @@
-description: gaz carbonique (100 000 mètres cubes extraits à 1 bar et 15° C)
+description: Montant du tarif de la redevance départementale des mines
+  pour le gaz carbonique (par 100 000 mètres cubes extraits à 1 bar et 15° C)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 67.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 72.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel.yaml
@@ -1,4 +1,5 @@
-description: gaz naturel (100 000 mètres cubes extraits)
+description: Montant du tarif de la redevance départementale des mines
+  pour le gaz naturel (par 100 000 mètres cubes extraits)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 473.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 513.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel_mer.yaml
@@ -1,4 +1,5 @@
-description: gaz naturel gisements en mer (100 000 mètres cubes extraits)
+description: Montant du tarif de la redevance départementale des mines
+  pour le gaz naturel de gisements en mer (par 100 000 mètres cubes extraits)
 metadata:
   unit: currency-EUR
 
@@ -11,3 +12,4 @@ values:
         2018-01-01: https://beta.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006069577/LEGISCTA000006162672/2019-01-01/
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+        2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_ge_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_ge_13.yaml
@@ -1,4 +1,5 @@
-description: lignites d'un pouvoir calorifique égal ou supérieur à 13 MJ/kg (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour les lignites d'un pouvoir calorifique égal ou supérieur à 13 MJ/kg (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 177.80
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 192.60
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_lt_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_lt_13.yaml
@@ -1,4 +1,5 @@
-description: lignites d'un pouvoir calorifique inférieur à 13 MJ/kg (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour les lignites d'un pouvoir calorifique inférieur à 13 MJ/kg (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 48.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 52.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lithium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lithium.yaml
@@ -1,4 +1,5 @@
-description: minerais de lithium (tonne de Li2O contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de lithium (tonne de Li2O contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 10.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 11.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/manganese.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/manganese.yaml
@@ -1,4 +1,5 @@
-description: minerais de manganèse (centaine de tonnes de manganèse contenu )
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de manganèse (centaine de tonnes de manganèse contenu )
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 75.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 82.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/molybdene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/molybdene.yaml
@@ -1,4 +1,5 @@
-description: minerais de molybdène (tonne de molybdène contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de molybdène (tonne de molybdène contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 50.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 54.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut.yaml
@@ -1,4 +1,5 @@
-description: pétrole brut (centaine de tonnes nettes extraites)
+description: Montant du tarif de la redevance départementale des mines
+  pour le pétrole brut (centaine de tonnes nettes extraites)
 metadata:
   unit: currency-EUR
 
@@ -17,3 +18,7 @@ values:
     value: 1448.80
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 1569.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut_mer.yaml
@@ -1,14 +1,15 @@
-description: pétrole brut gisements en mer (centaine de tonnes nettes extraites)
+description: Montant du tarif de la redevance départementale des mines
+  pour le pétrole brut de gisements en mer (centaine de tonnes nettes extraites)
 metadata:
   unit: currency-EUR
 
 values:
   2017-01-01:
-    value: 111
+    value: 111.0
     metadata:
       reference: 
         2017-01-01: https://beta.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006069577/LEGISCTA000006162672/2018-01-01/
         2018-01-01: https://beta.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006069577/LEGISCTA000006162672/2019-01-01/
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
-
+        2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/plomb.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/plomb.yaml
@@ -1,4 +1,5 @@
-description: minerais de plomb (centaine de tonnes de plomb contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de plomb (centaine de tonnes de plomb contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 112.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 132.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/potassium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/potassium.yaml
@@ -1,4 +1,5 @@
-description: sels de potassium (centaine de tonnes de K2O contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les sels de potassium (centaine de tonnes de K2O contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 52.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 57.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/propane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/propane.yaml
@@ -1,4 +1,5 @@
-description: propane (tonne nette livrée)
+description: Montant du tarif de la redevance départementale des mines
+  pour le propane (tonne nette livrée)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 6.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 7.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_abattage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_abattage.yaml
@@ -1,4 +1,5 @@
-description: sel extrait par abattage (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour le sel extrait par abattage (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 147.60
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 159.90
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_dissolution.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_dissolution.yaml
@@ -1,4 +1,5 @@
-description: sel extrait en dissolution par sondage et livré en dissolution (millier de tonnes de chlorure de sodium contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour le sel extrait en dissolution par sondage et livré en dissolution (millier de tonnes de chlorure de sodium contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 28.60
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 31.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_raffine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_raffine.yaml
@@ -1,4 +1,5 @@
-description: sel extrait en dissolution par sondage et livré raffiné (millier de tonnes nettes livrées)
+description: Montant du tarif de la redevance départementale des mines
+  pour le sel extrait en dissolution par sondage et livré raffiné (millier de tonnes nettes livrées)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 87.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 94.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/soufre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/soufre.yaml
@@ -1,4 +1,5 @@
-description: minerais de soufre autres que les pyrites de fer (tonne de soufre contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de soufre autres que les pyrites de fer (tonne de soufre contenu)
 metadata:
   unit: currency-EUR
 documentation: |
@@ -17,3 +18,7 @@ values:
     value: 1.60
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
+  2021-01-01:
+    value: 1.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/tungstene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/tungstene.yaml
@@ -1,4 +1,5 @@
-description: minerais de tungstène (tonne d'oxyde de tungstène (WO3) contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de tungstène (tonne d'oxyde de tungstène (WO3) contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 26.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 29.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/uranium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/uranium.yaml
@@ -1,4 +1,5 @@
-description: minerais d'uranium (quintal d'uranium contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais d'uranium (quintal d'uranium contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 59.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 64.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/zinc.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/zinc.yaml
@@ -1,4 +1,5 @@
-description: minerais de zinc (centaine de tonnes de zinc contenu)
+description: Montant du tarif de la redevance départementale des mines
+  pour les minerais de zinc (centaine de tonnes de zinc contenu)
 metadata:
   unit: currency-EUR
 
@@ -19,3 +20,7 @@ values:
     value: 102.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
+  2021-01-01:
+    value: 111.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="1.3.1",
+    version="1.3.2",
     author="OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2021.
* Zones impactées : 
  - `parameters/redevances/departementales/*`
  - `parameters/redevances/communales/*`
* Détails :
  - Revalorise les tarifs 2021 de la redevance départementale des mines (RDM).
  - Couvre tout l'[article 1587 II](https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/).

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

