### PR TITLE
Adapte les scripts de matrices au format de données 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 2.0.1 [#20](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/20)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2020.
+* Zones impactées : 
+  - `simulations/drfip.py`
+  - `simulations/estime_taxes_redevances.py`
+* Détails :
+  - Adapte les scripts de production des matrices 1121 et 1122 au nouveau format des des données de production.
+    * Adapte à l'évolution du format d'export des données de production de Camino.
+    * Permet l'emploi des données de production 2019 au format 2020 et des données de production 2020 au format 2021.
+
 # 2.0.0 [#19](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/19)
 
 * Évolution du système socio-fiscal.

--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,14 @@
 [SIMULATIONS]
+# TODO renommer SIMULATIONS en PRODUCTION ?
 
-periode=2019
+# periode=2019
+# titres=/Volumes/Transcend2/beta/camino_2020/data/20201216-08h18-camino-titres-1209.csv
+# activites=/Volumes/Transcend2/beta/camino_2020/data/20201216-21h36-camino-activites-569.csv
+# entreprises=/Volumes/Transcend2/beta/camino_2020/data/20201216-08h18-camino-entreprises-1745.csv
 
-titres=/Volumes/Transcend2/beta/camino_2020/data/20201216-08h18-camino-titres-1209.csv
-activites=/Volumes/Transcend2/beta/camino_2020/data/20201216-21h36-camino-activites-569.csv
-entreprises=/Volumes/Transcend2/beta/camino_2020/data/20201216-08h18-camino-entreprises-1745.csv
+# année de production (période des données)
+periode=2020
+titres=/Users/sch/Desktop/camino_2021_production_2020/20211206-05h04-camino-titres-2398.csv
+# activites=/Users/sch/Desktop/camino_2021_production_2020/20211206-05h16-camino-activites-7102.csv
+activites=/Users/sch/Desktop/camino_2021_production_2020/20211206-10h32-camino-activites-578.csv
+entreprises=/Users/sch/Desktop/camino_2021_production_2020/20211206-05h13-camino-entreprises-1780.csv

--- a/openfisca_france_fiscalite_miniere/tests/simulations/test_estime_taxes_redevances.py
+++ b/openfisca_france_fiscalite_miniere/tests/simulations/test_estime_taxes_redevances.py
@@ -118,8 +118,9 @@ def tax_benefit_system():
 
 @pytest.fixture
 def simulation_data(titres_data, activites_data):
-    full_data = get_simulation_full_data(titres_data, activites_data)
-    data = clean_data(full_data)
+    data_period = 2019
+    full_data = get_simulation_full_data(titres_data, activites_data, data_period)
+    data = clean_data(full_data, data_period)
     return data
 
 
@@ -146,7 +147,13 @@ def test_get_titres_annee(communes_par_titre, activite_par_titre, activites_data
 
 
 def test_get_simulation_full_data(titres_data, activites_data):
-    full_data = get_simulation_full_data(titres_data, activites_data)  # act
+    data_period = 2019
+
+    full_data = get_simulation_full_data(
+        titres_data,
+        activites_data,
+        data_period
+        )  # act
 
     assert not full_data.empty
     assert('id' not in full_data.columns)
@@ -154,9 +161,10 @@ def test_get_simulation_full_data(titres_data, activites_data):
 
 
 def test_clean_data(titres_data, activites_data):
-    full_data = get_simulation_full_data(titres_data, activites_data)
+    data_period = 2019
+    full_data = get_simulation_full_data(titres_data, activites_data, data_period)
 
-    data = clean_data(full_data)  # act
+    data = clean_data(full_data, data_period)  # act
 
     assert((data['titre_id'] == [
         'titre_3+commune_x_p1', 'titre_3+commune_x_p2', 'titre_2'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="2.0.0",
+    version="2.0.1",
     author="OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers=[

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -14,6 +14,7 @@ def build_designations_entreprises(data):
 
 
 def calculate_production_communale(data):
+    # renseignements_orNet est renseignements_orExtrait à partir des data 2020
     return round(
         data["renseignements_orNet"] * (data["surface_communale"]
         / data["surface_totale"]),

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -155,7 +155,9 @@ def generate_matrice_drfip_guyane(data, annee_production, timestamp):
         f'matrice_drfip_guyane_production_{annee_production}_{timestamp}.csv',
         index=False,
         sep=';',
-        encoding='utf-8')
+        encoding='utf-8',
+        decimal=','
+        )
 
 
 def generate_matrice_annexe_drfip_guyane(data, annee_production, timestamp):
@@ -209,5 +211,6 @@ def generate_matrice_annexe_drfip_guyane(data, annee_production, timestamp):
         f'matrice_annexe_drfip_guyane_production_{annee_production}_{timestamp}.csv',
         index=False,
         sep=';',
-        encoding='utf-8'
+        encoding='utf-8',
+        decimal=','
         )

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -451,7 +451,7 @@ if __name__ == "__main__":
         full_data,
         "rapport trimestriel d'exploitation d'or en Guyane"
         )
-    rapports_trimestriels.renseignements_environnement.fillna(0, inplace=True)  # en 2020, 20 vides
+    rapports_trimestriels.renseignements_environnement.fillna(0, inplace=True)  # en 2020, 20 vides pour statuts autres que "déposé"
     assert (
         rapports_trimestriels.renseignements_environnement.notnull()
         ).all()  # + 1 cas ajouté

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -447,6 +447,7 @@ if __name__ == "__main__":
         full_data,
         "rapport trimestriel d'exploitation d'or en Guyane"
         )
+    rapports_trimestriels.renseignements_environnement.fillna(0, inplace=True)  # en 2020, 20 vides
     assert (
         rapports_trimestriels.renseignements_environnement.notnull()
         ).all()  # + 1 cas ajouté

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -223,7 +223,7 @@ def clean_data(data, data_period):
     quantites_chiffrees = data
     quantites_chiffrees.loc[
         renseignements_or
-        ] = data.renseignements_orExtrait.fillna(0.)
+        ] = data[renseignements_or].fillna(0.)
     quantites_chiffrees = convertit_grammes_a_kilo(
         quantites_chiffrees, renseignements_or
         )

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -2,10 +2,10 @@ import configparser
 import logging
 import re
 import time
-
-import numpy
-import pandas  # noqa: I201
 from typing import List
+
+import numpy  # noqa: I201
+import pandas  # noqa: I201
 
 from openfisca_core.simulation_builder import SimulationBuilder  # noqa: I100
 
@@ -25,14 +25,17 @@ COLONNE_COMMUNES_2019 = "communes"
 COLONNE_COMMUNES_2020 = "communes (surface calculee km2)"
 
 RAPPORT_ANNUEL_OR_2019 = ["rapport annuel de production d'or en Guyane"]
-RAPPORT_ANNUEL_OR_2020 = ["rapport d'exploitation (permis et concessions M)", "rapport d'exploitation (autorisations M)"]
+RAPPORT_ANNUEL_OR_2020 = [
+    "rapport d'exploitation (permis et concessions M)",
+    "rapport d'exploitation (autorisations M)"
+    ]
 
 
 # ADAPT INPUT DATA
 
 def get_activites_data(csv_activites, data_period):
     activite_par_titre: pandas.DataFrame = pandas.read_csv(csv_activites)
-    
+
     renseignements_or = COLONNE_OR_2019 if (data_period == 2019) else COLONNE_OR_2020
     activites_data = activite_par_titre[
         [
@@ -142,7 +145,7 @@ def dispatch_titres_multicommunes(data, data_period):
         communes,
         ignore_index=True  # ! pandas v 1.1.0+
         ).dropna(subset=['titre_id'])  # dropping NaN values from exploded empty lists
-    
+
     logging.debug(une_commune_par_titre[
         ['titre_id', 'periode', communes, renseignements_or]
         ])
@@ -251,7 +254,8 @@ def clean_data(data, data_period):
 
     # on éclate les titres multicommunaux en une ligne par titre+commune unique
     # attention : on refait l'index du dataframe pour distinguer les lignes résultat.
-    une_commune_par_titre = dispatch_titres_multicommunes(quantites_chiffrees, data_period)
+    une_commune_par_titre = dispatch_titres_multicommunes(
+        quantites_chiffrees, data_period)
 
     return une_commune_par_titre
 
@@ -294,7 +298,11 @@ def add_entreprises_data(data, entreprises_data):
     return merged_data
 
 
-def select_reports(data: pandas.DataFrame, type: List[str]) -> pandas.DataFrame:  # noqa: A002
+def select_reports(
+    data: pandas.DataFrame,
+    type: List[str]  # noqa: A002
+    ) -> pandas.DataFrame:
+
     if len(type) == 2:  # 2020
         filtre_reports = (data.type == type[0]) | (data.type == type[1])
         selected_reports = data[filtre_reports]
@@ -381,7 +389,8 @@ if __name__ == "__main__":
 
     renseignements_or = COLONNE_OR_2019 if (data_period == 2019) else COLONNE_OR_2020
     communes = COLONNE_COMMUNES_2019 if (data_period == 2019) else COLONNE_COMMUNES_2020
-    rapport_annuel = RAPPORT_ANNUEL_OR_2019 if (data_period == 2019) else RAPPORT_ANNUEL_OR_2020
+    rapport_annuel = RAPPORT_ANNUEL_OR_2019 if (
+        data_period == 2019) else RAPPORT_ANNUEL_OR_2020
 
     activite_par_titre = get_activites_data(csv_activites, data_period)
     activites_data = get_activites_annee(activite_par_titre, data_period)
@@ -398,8 +407,8 @@ if __name__ == "__main__":
         rapport_annuel
         )
     rapports_annuels[renseignements_or].fillna(0., inplace=True)  # en 2020, 1 NaN
-    assert (rapports_annuels[renseignements_or].notnull()).all()  # en 2019 : + 1 cas ajouté
-    
+    assert (rapports_annuels[renseignements_or].notnull()
+            ).all()  # en 2019 : + 1 cas ajouté
 
     cleaned_data = clean_data(
         rapports_annuels,
@@ -434,7 +443,8 @@ if __name__ == "__main__":
         full_data,
         "rapport trimestriel d'exploitation d'or en Guyane"
         )
-    rapports_trimestriels.renseignements_environnement.fillna(0, inplace=True)  # en 2020, 20 vides pour statuts autres que "déposé"
+    rapports_trimestriels.renseignements_environnement.fillna(
+        0, inplace=True)  # en 2020, 20 vides pour statuts autres que "déposé"
     assert (
         rapports_trimestriels.renseignements_environnement.notnull()
         ).all()  # + 1 cas ajouté
@@ -512,7 +522,8 @@ if __name__ == "__main__":
     resultat['categorie_entreprise'] = data.categorie_entreprise
 
     # Base des redevances :
-    resultat['renseignements_orNet'] = data[renseignements_or]  # !! changement de nom 2020 non propagé
+    # !! changement de nom 2020 non propagé
+    resultat['renseignements_orNet'] = data[renseignements_or]
 
     # Redevance départementale :
     resultat['tarifs_rdm'] = numpy.where(

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -137,6 +137,7 @@ def dispatch_titres_multicommunes(data, data_period):
     communes = COLONNE_COMMUNES_2019 if (data_period == 2019) else COLONNE_COMMUNES_2020
 
     data[communes] = data[communes].str.split(pat=';')
+
     une_commune_par_titre = data.explode(
         communes,
         ignore_index=True  # ! pandas v 1.1.0+
@@ -234,9 +235,6 @@ def clean_data(data, data_period):
     communes = COLONNE_COMMUNES_2019 if (data_period == 2019) else COLONNE_COMMUNES_2020
     renseignements_or = COLONNE_OR_2019 if (data_period == 2019) else COLONNE_OR_2020
 
-    print("👹👹 clean_data - data")
-    print(data.head())
-
     quantites_chiffrees = data
     quantites_chiffrees.loc[
         renseignements_or
@@ -245,9 +243,6 @@ def clean_data(data, data_period):
         quantites_chiffrees, renseignements_or
         )
     logging.debug("👹👹👹 ", quantites_chiffrees[renseignements_or].head())
-
-    print("👹👹 quantites_chiffrees")
-    print(quantites_chiffrees.head())
 
     logging.debug(len(quantites_chiffrees), "CLEANED DATA")
     logging.debug(quantites_chiffrees[
@@ -300,9 +295,6 @@ def add_entreprises_data(data, entreprises_data):
 
 
 def select_reports(data: pandas.DataFrame, type: List[str]) -> pandas.DataFrame:  # noqa: A002
-    print("👹👹 select_reports - data")
-    print(data[["annee", "type"]].head())
-
     if len(type) == 2:  # 2020
         selected_reports = data[(data.type[0] == type) or (data.type == type[1])]
     else:
@@ -400,18 +392,11 @@ if __name__ == "__main__":
 
     full_data = get_simulation_full_data(titres_data, activites_data, data_period)
 
-    print("👹👹 full_data")
-    print(full_data.head())
-
     rapports_annuels = select_reports(
         full_data,
         rapport_annuel
         )
     rapports_annuels[renseignements_or].fillna(0., inplace=True)  # en 2020, 1 NaN
-
-    print("👹👹 rapports_annuels", renseignements_or)
-    print(rapports_annuels[["titre_id", renseignements_or]].head())
-    
     assert (rapports_annuels[renseignements_or].notnull()).all()  # en 2019 : + 1 cas ajouté
     
 
@@ -419,15 +404,12 @@ if __name__ == "__main__":
         rapports_annuels,
         data_period
         )  # titres ayant des rapports annuels d'activité citant la production
-    print("👹👹 cleaned_data")
-    print(cleaned_data.head())
+
     data = add_entreprises_data(cleaned_data, entreprises_data)
 
     # SIMULATION
 
-    print("👹👹 data")
-    print(data.head())
-    simulation_period = '2020'
+    simulation_period = '2021'
     tax_benefit_system = FranceFiscaliteMiniereTaxBenefitSystem()
     current_parameters = tax_benefit_system.parameters(simulation_period)
 

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -296,7 +296,8 @@ def add_entreprises_data(data, entreprises_data):
 
 def select_reports(data: pandas.DataFrame, type: List[str]) -> pandas.DataFrame:  # noqa: A002
     if len(type) == 2:  # 2020
-        selected_reports = data[(data.type[0] == type) or (data.type == type[1])]
+        filtre_reports = (data.type == type[0]) | (data.type == type[1])
+        selected_reports = data[filtre_reports]
     else:
         selected_reports = data[data.type == type]
     logging.debug(len(selected_reports), "SELECTED REPORTS ", type)

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -5,6 +5,7 @@ import time
 
 import numpy
 import pandas  # noqa: I201
+from typing import List
 
 from openfisca_core.simulation_builder import SimulationBuilder  # noqa: I100
 
@@ -23,8 +24,8 @@ COLONNE_OR_2020 = "substancesFiscales_auru"  # ou "renseignements_orExtrait" ?
 COLONNE_COMMUNES_2019 = "communes"
 COLONNE_COMMUNES_2020 = "communes (surface calculee km2)"
 
-RAPPORT_ANNUEL_OR_2019 = "rapport annuel de production d'or en Guyane"
-RAPPORT_ANNUEL_OR_2020 = "rapport d'exploitation (permis et concessions M)"  # et "rapport d'exploitation (autorisations M)" ? oui ?
+RAPPORT_ANNUEL_OR_2019 = ["rapport annuel de production d'or en Guyane"]
+RAPPORT_ANNUEL_OR_2020 = ["rapport d'exploitation (permis et concessions M)", "rapport d'exploitation (autorisations M)"]
 
 
 # ADAPT INPUT DATA
@@ -298,11 +299,14 @@ def add_entreprises_data(data, entreprises_data):
     return merged_data
 
 
-def select_reports(data: pandas.DataFrame, type: str) -> pandas.DataFrame:  # noqa: A002
+def select_reports(data: pandas.DataFrame, type: List[str]) -> pandas.DataFrame:  # noqa: A002
     print("👹👹 select_reports - data")
     print(data[["annee", "type"]].head())
 
-    selected_reports = data[data.type == type]
+    if len(type) == 2:  # 2020
+        selected_reports = data[(data.type[0] == type) or (data.type == type[1])]
+    else:
+        selected_reports = data[data.type == type]
     logging.debug(len(selected_reports), "SELECTED REPORTS ", type)
     return selected_reports
 


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2020.
* Zones impactées : 
  - `simulations/drfip.py`
  - `simulations/estime_taxes_redevances.py`
* Détails :
  - Adapte les scripts de production des matrices 1121 et 1122 au nouveau format des des données de production
    * Adapte à l'évolution du format d'export des données de production de Camino 
    * Permet l'emploi des données de production 2019 au format 2020 et des données de production 2020 au format 2021

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France — Fiscalité Minière (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus