### PR TITLE
Génère les matrices 1403 et 1404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 2.0.2 [#21](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/21)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2020.
+* Zones impactées : 
+  - `simulations/drfip.py`
+  - `simulations/estime_taxes_redevances.py`
+* Détails :
+  - Ajoute la génération des matrices 1403 et 1404 aux scripts de `simulations/`.
+  - Matrices au format 2021. Code exécuté sur données de production 2020.
+
 ### 2.0.1 [#20](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/20)
 
 * Changement mineur.

--- a/openfisca_france_fiscalite_miniere/tests/simulations/test_estime_taxes_redevances.py
+++ b/openfisca_france_fiscalite_miniere/tests/simulations/test_estime_taxes_redevances.py
@@ -1,7 +1,5 @@
 import logging
 
-import numpy
-
 from openfisca_france_fiscalite_miniere import (
     CountryTaxBenefitSystem as FranceFiscaliteMiniereTaxBenefitSystem
     )
@@ -11,7 +9,6 @@ from pandas import DataFrame, Series
 import pytest
 
 from simulations.estime_taxes_redevances import (
-    build_simulation,
     clean_data,
     convertit_grammes_a_kilo,
     get_activites_annee,
@@ -38,7 +35,7 @@ def communes_par_titre() -> DataFrame:
         'substances': ['or', 'or', 'or;substances connexes', 'or'],
         'communes': [
             'commune_1 (0.123)', 'commune_1 (0.456)',
-            'commune_x_p1 (42.0);commune_x_p2 (0.216)',
+            'Cayenne_p1 (42.0);Cayenne_p2 (0.216)',
             'temp (0.01)'
             ],
         'departements': ['Guyane', 'MonDepartement', 'Guyane', 'Guyane'],
@@ -158,38 +155,6 @@ def test_get_simulation_full_data(titres_data, activites_data):
     assert not full_data.empty
     assert('id' not in full_data.columns)
     assert((full_data['titre_id'] == ['titre_3', 'titre_2']).all())
-
-
-def test_clean_data(titres_data, activites_data):
-    data_period = 2019
-    full_data = get_simulation_full_data(titres_data, activites_data, data_period)
-
-    data = clean_data(full_data, data_period)  # act
-
-    assert((data['titre_id'] == [
-        'titre_3+commune_x_p1', 'titre_3+commune_x_p2', 'titre_2'
-        ]).all())
-    assert (data.renseignements_orNet.values == [3., 3., 2.]).all()
-
-
-def test_build_simulation(tax_benefit_system, simulation_data):
-    simulation = build_simulation(
-        tax_benefit_system, ANNEE_ACTIVITES,
-        simulation_data.titre_id, simulation_data.communes
-        )  # act
-
-    simulation_societes = simulation.populations['societe'].ids
-    simulation_communes = simulation.populations['commune'].ids
-
-    # ok si pas de doublons sur societes et communes
-    unique_societes, unique_societes_counts = numpy.unique(
-        simulation_societes, return_counts=True
-        )
-    assert any(count == 1 for count in unique_societes_counts)
-    unique_communes, unique_communes_counts = numpy.unique(
-        simulation_communes, return_counts=True
-        )
-    assert any(count == 1 for count in unique_communes_counts)
 
 
 def test_convertit_grammes_a_kilo():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="2.0.1",
+    version="2.0.2",
     author="OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers=[

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -235,17 +235,6 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
     ]
 
     matrice_1403 = pandas.DataFrame(columns = colonnes_1403)
-    print("🍄 data resultats", data.head())
-    # 🍄 data resultats Index(['titre_id', 'communes', 'commune_exploitation_principalenom_entreprise',
-    #    'adresse_entreprise', 'siren', 'categorie_entreprise', 'substances',
-    #    'substancesFiscales_auru', 'surface_communale',
-    #    'surface_totaletarifs_rdm',
-    #    'redevance_departementale_des_mines_aurifere_kg', 'tarifs_rcm',
-    #    'redevance_communale_des_mines_aurifere_kg', 'taxe_tarif_pme',
-    #    'taxe_tarif_autres', 'investissement', 'taxe_guyane', 'drfip',
-    #    'observation', 'commune_exploitation_principale', 'surface_totale',
-    #    'nom_entreprise', 'renseignements_orNet', 'tarifs_rdm'],
-    #   dtype='object')
 
     data_sip_cayenne = get_sip_data(data, "commune_exploitation_principale", sip_guyane_cayenne)
     data_sip_kourou = get_sip_data(data, "commune_exploitation_principale", sip_guyane_kourou)
@@ -258,20 +247,20 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
     ]
 
     matrice_1403["Redevance départementale"] = [
-        data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"].sum(),
-        data_sip_kourou["redevance_departementale_des_mines_aurifere_kg"].sum(),
-        data_sip_st_laurent_du_maroni["redevance_departementale_des_mines_aurifere_kg"].sum()
+        data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"].sum().astype(int),
+        data_sip_kourou["redevance_departementale_des_mines_aurifere_kg"].sum().astype(int),
+        data_sip_st_laurent_du_maroni["redevance_departementale_des_mines_aurifere_kg"].sum().astype(int)
     ]
 
     matrice_1403["Redevance communale"] = [
-        data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"].sum(),
-        data_sip_kourou["redevance_communale_des_mines_aurifere_kg"].sum(),
-        data_sip_st_laurent_du_maroni["redevance_communale_des_mines_aurifere_kg"].sum()
+        data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
+        data_sip_kourou["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
+        data_sip_st_laurent_du_maroni["redevance_communale_des_mines_aurifere_kg"].sum().astype(int)
     ]
     matrice_1403["Taxe minière sur l'or de Guyane"] = [
-        data_sip_cayenne["taxe_guyane"].sum(),
-        data_sip_kourou["taxe_guyane"].sum(),
-        data_sip_st_laurent_du_maroni["taxe_guyane"].sum()
+        data_sip_cayenne["taxe_guyane"].sum().astype(int),
+        data_sip_kourou["taxe_guyane"].sum().astype(int),
+        data_sip_st_laurent_du_maroni["taxe_guyane"].sum().astype(int)
     ]
 
     total_rdcm_taxe = (
@@ -291,8 +280,6 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
         len(data_sip_kourou),
         len(data_sip_st_laurent_du_maroni)
     ]
-
-    print("🍄 matrice_1403", matrice_1403)
 
     matrice_1403.to_csv(
         f'matrice_1403_drfip_guyane_production_{annee_production}_{timestamp}.csv',

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -394,3 +394,23 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
         encoding='utf-8',
         decimal=','
         )
+    
+    data_sip_kourou = get_sip_data(data, "commune_exploitation_principale", sip_guyane_kourou)
+    matrice_1404_sip_kourou = generate_matrice_1404_sip(colonnes_1404, data_sip_kourou, sip_guyane_kourou_nom)
+    matrice_1404_sip_kourou.to_csv(
+        f'matrice_1404_sip_guyane_kourou_production_{annee_production}_{timestamp}.csv',
+        index=False,
+        sep=';',
+        encoding='utf-8',
+        decimal=','
+        )
+
+    data_sip_st_laurent_du_maroni = get_sip_data(data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
+    matrice_1404_sip_st_laurent_du_maroni = generate_matrice_1404_sip(colonnes_1404, data_sip_st_laurent_du_maroni, sip_guyane_st_laurent_du_maroni_nom)
+    matrice_1404_sip_st_laurent_du_maroni.to_csv(
+        f'matrice_1404_sip_guyane_st_laurent_du_maroni_production_{annee_production}_{timestamp}.csv',
+        index=False,
+        sep=';',
+        encoding='utf-8',
+        decimal=','
+        )

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -344,25 +344,30 @@ def generate_matrice_1404_drfip_guyane(data, annee_production, timestamp):
     
     matrice_1404["Service de la direction générale des finances publiques en charge du recouvrement"] = [sip_guyane_cayenne_nom] * NB_ROWS_SIP_CAYENNE
     matrice_1404["Articles des rôles"] = data_sip_cayenne["titre_id"].index
-
+    
+    # Avant affectation, on valide le bon alignement des articles à défaut d'index commun aux DataFrame
     exploitants_sip_cayenne = build_designations_entreprises(data_sip_cayenne)
-    print("exploitants_sip_cayenne", exploitants_sip_cayenne)
-    matrice_1404["Désignation des exploitants"] = exploitants_sip_cayenne
+    assert (matrice_1404["Articles des rôles"].values == exploitants_sip_cayenne.index).all()
+    matrice_1404["Désignation des exploitants"] = exploitants_sip_cayenne.values
 
     # DEPARTEMENTS ET COMMUNES sur les territoires desquels fonctionnent les exploitations :
     matrice_1404["Départements"] = ['Guyane'] * NB_ROWS_SIP_CAYENNE  # col. 4
-    matrice_1404["Communes"] = data_sip_cayenne["commune_exploitation_principale"]  # col. 5
+    matrice_1404["Communes"] = data_sip_cayenne["commune_exploitation_principale"].values  # col. 5
 
     # ELEMENTS SERVANT DE BASE A LA REPARTITION pour chaque exploitation :
     matrice_1404["Revenus imposables à la TFPB (état 1123, col. 3)"] = [None] * NB_ROWS_SIP_CAYENNE  # vide en drfip
-    matrice_1404["Tonnages extraits :"] = calculate_production_communale(data_sip_cayenne)
+
+    # Avant affectation, on valide le bon alignement des articles à défaut d'index commun aux DataFrame
+    production_communale = calculate_production_communale(data_sip_cayenne)
+    assert (matrice_1404["Articles des rôles"].values == production_communale.index).all()
+    matrice_1404["Tonnages extraits :"] = production_communale.values
 
     # REDEVANCE DÉPARTEMENTALE :
-    matrice_1404["Produit net de la redevance (RDM)"] = data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"]
+    matrice_1404["Produit net de la redevance (RDM)"] = data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"].values
     matrice_1404["Sommes revenant aux départements désignés dans la colonne 4 (a)"] = matrice_1404["Produit net de la redevance (RDM)"]
 
     # REDEVANCE COMMUNALE :
-    matrice_1404["Produit net de la redevance (RCM)"] = data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"]  # col. 10
+    matrice_1404["Produit net de la redevance (RCM)"] = data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"].values  # col. 10
     # > Répartition
     matrice_1404["1ère fraction (col. 10 x 35%)"] = matrice_1404["Produit net de la redevance (RCM)"] * 0.35
     matrice_1404["2ème fraction (col. 10 x 10%)"] = matrice_1404["Produit net de la redevance (RCM)"] * 0.1
@@ -373,7 +378,7 @@ def generate_matrice_1404_drfip_guyane(data, annee_production, timestamp):
     matrice_1404["Total (col. 14 + col. 15)"] = matrice_1404["1ère fraction (b)"] + matrice_1404["2ème fraction (a)"]
 
     # TAXE MINIÈRE SUR L'OR DE GUYANE
-    matrice_1404["Produit net de la taxe"] = data_sip_cayenne["taxe_guyane"]
+    matrice_1404["Produit net de la taxe"] = data_sip_cayenne["taxe_guyane"].values
     # > Répartition
     matrice_1404["Région de Guyane"] = matrice_1404["Produit net de la taxe"]
     matrice_1404["Conservatoire"] = [None] * NB_ROWS_SIP_CAYENNE  # vide en 2020

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -288,3 +288,50 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
         encoding='utf-8',
         decimal=','
         )
+
+
+def generate_matrice_1404_drfip_guyane(data, annee_production, timestamp):
+    colonnes_1404 = [
+        "Service de la direction générale des finances publiques en charge du recouvrement",  # SIP
+        "Articles des rôles",
+        "Désignation des exploitants",
+
+        # DEPARTEMENTS ET COMMUNES sur les territoires desquels fonctionnent les exploitations :
+        "Départements",  # col. 4
+        "Communes",  # col. 5
+
+        # ELEMENTS SERVANT DE BASE A LA REPARTITION pour chaque exploitation :
+        "Revenus imposables à la TFPB (état 1123, col. 3)",  # vide en drfip
+        "Tonnages extraits :",
+
+        # REDEVANCE DÉPARTEMENTALE :
+        "Produit net de la redevance",
+        "Sommes revenant aux départements désignés dans la colonne 4 (a)",
+
+        # REDEVANCE COMMUNALE :
+        "Produit net de la redevance",  # col. 10
+        # > Répartition
+        "1ère fraction (col. 10 x 35%)",
+        "2ème fraction (col. 10 x 10%)",
+        "3ème fraction (col. 10 x 55%)",
+        # > Sommes revenant aux communes désignées dans la colonne 5 au titre des 1ère et 2ème fractions
+        "1ère fraction (b)",  # col. 14
+        "2ème fraction (a)",  # col. 15
+        "Total (col. 14 + col. 15)",
+
+        # TAXE MINIÈRE SUR L'OR DE GUYANE
+        "Produit net de la taxe",
+        # > Répartition
+        "Région de Guyane",
+        "Conservatoire",  # vide en 2020
+        "Observations"
+    ]
+
+    matrice_1404 = pandas.DataFrame(columns = colonnes_1404)
+    matrice_1404.to_csv(
+        f'matrice_1404_drfip_guyane_production_{annee_production}_{timestamp}.csv',
+        index=False,
+        sep=';',
+        encoding='utf-8',
+        decimal=','
+        )

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -1,7 +1,12 @@
 import numpy
 import pandas  # noqa: I201
 
-from simulations.sip import *
+from simulations.sip import (
+    get_sip_data,
+    sip_guyane_cayenne, sip_guyane_cayenne_nom,
+    sip_guyane_kourou, sip_guyane_kourou_nom,
+    sip_guyane_st_laurent_du_maroni, sip_guyane_st_laurent_du_maroni_nom
+    )
 
 
 def build_designations_entreprises(data):
@@ -219,7 +224,7 @@ def generate_matrice_annexe_drfip_guyane(data, annee_production, timestamp):
 
 def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
     colonnes_1403 = [
-        "Service de la Direction générale des finances publiques en charge du recouvrement",  # Circonscription
+        "Service de la Direction générale des finances publiques en charge du recouvrement",  # Circonscription  # noqa: E501
         "Redevance départementale",  # Produit net = col. 2
         "Redevance communale",  # Produit net = col. 3
         "Taxe minière sur l'or de Guyane",  # Produit net = col. 4
@@ -243,26 +248,32 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
     data_sip_st_laurent_du_maroni = get_sip_data(
         data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
 
-    matrice_1403["Service de la Direction générale des finances publiques en charge du recouvrement"] = [
+    matrice_1403[
+        "Service de la Direction générale des finances publiques en charge du recouvrement"  # noqa: E501
+        ] = [
         sip_guyane_cayenne_nom,
         sip_guyane_kourou_nom,
         sip_guyane_st_laurent_du_maroni_nom
         ]
 
     matrice_1403["Redevance départementale"] = [
-        data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"].sum().astype(
-            int),
-        data_sip_kourou["redevance_departementale_des_mines_aurifere_kg"].sum().astype(
-            int),
-        data_sip_st_laurent_du_maroni["redevance_departementale_des_mines_aurifere_kg"].sum(
-            ).astype(int)
+        data_sip_cayenne[
+            "redevance_departementale_des_mines_aurifere_kg"
+            ].sum().astype(int),
+        data_sip_kourou[
+            "redevance_departementale_des_mines_aurifere_kg"
+            ].sum().astype(int),
+        data_sip_st_laurent_du_maroni[
+            "redevance_departementale_des_mines_aurifere_kg"
+            ].sum().astype(int)
         ]
 
     matrice_1403["Redevance communale"] = [
         data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
         data_sip_kourou["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
-        data_sip_st_laurent_du_maroni["redevance_communale_des_mines_aurifere_kg"].sum().astype(
-            int)
+        data_sip_st_laurent_du_maroni[
+            "redevance_communale_des_mines_aurifere_kg"
+            ].sum().astype(int)
         ]
     matrice_1403["Taxe minière sur l'or de Guyane"] = [
         data_sip_cayenne["taxe_guyane"].sum().astype(int),
@@ -276,15 +287,21 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
         + matrice_1403["Taxe minière sur l'or de Guyane"]
         )
 
-    matrice_1403["Sommes revenant à Région de Guyane"] = matrice_1403["Taxe minière sur l'or de Guyane"]
+    matrice_1403["Sommes revenant à Région de Guyane"] = matrice_1403[
+        "Taxe minière sur l'or de Guyane"
+        ]
     matrice_1403["Sommes revenant à Conservatoire de biodiversité"] = [None, None, None]
     matrice_1403["Frais d'assiette et de recouvrement"] = (
-        total_rdcm_taxe * 0.08).astype(int)  # 4.4% mais à 8% en 2020, perte des centimes
+        total_rdcm_taxe * 0.08
+        ).astype(int)  # 4.4% mais à 8% en 2020, perte des centimes
     matrice_1403["Dégrèvements et non-valeurs"] = [None,
         None, None]  # 3.6% mais vide en 2020
-    matrice_1403["Total des colonnes 7 et 8"] = matrice_1403["Frais d'assiette et de recouvrement"]
-    matrice_1403["Total des colonnes 2, 3 ,4 et 9"] = total_rdcm_taxe + \
-        matrice_1403["Total des colonnes 7 et 8"]
+    matrice_1403["Total des colonnes 7 et 8"] = matrice_1403[
+        "Frais d'assiette et de recouvrement"
+        ]
+    matrice_1403["Total des colonnes 2, 3 ,4 et 9"] = total_rdcm_taxe + matrice_1403[
+        "Total des colonnes 7 et 8"
+        ]
     matrice_1403["Nombre d'articles des rôles"] = [
         data_sip_cayenne["nom_entreprise"].nunique(),
         data_sip_kourou["nom_entreprise"].nunique(),
@@ -305,17 +322,20 @@ def generate_matrice_1404_sip(columns_1404, data_sip, sip_name):
 
     NB_ROWS_SIP = len(data_sip)
 
-    matrice_1404_sip["Service de la direction générale des finances publiques en charge du recouvrement"] = [
-        sip_name] * NB_ROWS_SIP
+    matrice_1404_sip[
+        "Service de la direction générale des finances publiques en charge du recouvrement"  # noqa: E501
+        ] = [sip_name] * NB_ROWS_SIP
     matrice_1404_sip["Articles des rôles"] = data_sip["titre_id"].index
 
-    # Avant affectation, on valide le bon alignement des articles à défaut d'index commun aux DataFrame
+    # Avant affectation, on valide le bon alignement des articles
+    # à défaut d'index commun aux DataFrame
     exploitants_sip_cayenne = build_designations_entreprises(data_sip)
     assert (matrice_1404_sip["Articles des rôles"].values
             == exploitants_sip_cayenne.index).all()
     matrice_1404_sip["Désignation des exploitants"] = exploitants_sip_cayenne.values
 
-    # DEPARTEMENTS ET COMMUNES sur les territoires desquels fonctionnent les exploitations :
+    # DEPARTEMENTS ET COMMUNES
+    # sur les territoires desquels fonctionnent les exploitations :
     matrice_1404_sip["Départements"] = ['Guyane'] * NB_ROWS_SIP  # col. 4
     # col. 5
     matrice_1404_sip["Communes"] = data_sip["commune_exploitation_principale"].values
@@ -324,31 +344,49 @@ def generate_matrice_1404_sip(columns_1404, data_sip, sip_name):
     matrice_1404_sip["Revenus imposables à la TFPB (état 1123, col. 3)"] = [
         None] * NB_ROWS_SIP  # vide en drfip
 
-    # Avant affectation, on valide le bon alignement des articles à défaut d'index commun aux DataFrame
+    # Avant affectation, on valide le bon alignement des articles
+    # à défaut d'index commun aux DataFrame
     production_communale = calculate_production_communale(data_sip)
     assert (matrice_1404_sip["Articles des rôles"].values
             == production_communale.index).all()
     matrice_1404_sip["Tonnages extraits :"] = production_communale.values
 
     # REDEVANCE DÉPARTEMENTALE :
-    matrice_1404_sip["Produit net de la redevance (RDM)"] = data_sip["redevance_departementale_des_mines_aurifere_kg"].values
-    matrice_1404_sip["Sommes revenant aux départements désignés dans la colonne 4 (a)"] = matrice_1404_sip[
-        "Produit net de la redevance (RDM)"]
+    matrice_1404_sip["Produit net de la redevance (RDM)"] = data_sip[
+        "redevance_departementale_des_mines_aurifere_kg"
+        ].values
+    matrice_1404_sip[
+        "Sommes revenant aux départements désignés dans la colonne 4 (a)"
+        ] = matrice_1404_sip["Produit net de la redevance (RDM)"]
 
     # REDEVANCE COMMUNALE :
     # col. 10
-    matrice_1404_sip["Produit net de la redevance (RCM)"] = data_sip["redevance_communale_des_mines_aurifere_kg"].values
+    matrice_1404_sip["Produit net de la redevance (RCM)"] = data_sip[
+        "redevance_communale_des_mines_aurifere_kg"
+        ].values
     # > Répartition
-    matrice_1404_sip["1ère fraction (col. 10 x 35%)"] = matrice_1404_sip["Produit net de la redevance (RCM)"] * 0.35
-    matrice_1404_sip["2ème fraction (col. 10 x 10%)"] = matrice_1404_sip["Produit net de la redevance (RCM)"] * 0.1
-    matrice_1404_sip["3ème fraction (col. 10 x 55%)"] = matrice_1404_sip["Produit net de la redevance (RCM)"] * 0.55
-    # > Sommes revenant aux communes désignées dans la colonne 5 au titre des 1ère et 2ème fractions
+    matrice_1404_sip["1ère fraction (col. 10 x 35%)"] = matrice_1404_sip[
+        "Produit net de la redevance (RCM)"
+        ] * 0.35
+    matrice_1404_sip["2ème fraction (col. 10 x 10%)"] = matrice_1404_sip[
+        "Produit net de la redevance (RCM)"
+        ] * 0.1
+    matrice_1404_sip["3ème fraction (col. 10 x 55%)"] = matrice_1404_sip[
+        "Produit net de la redevance (RCM)"
+        ] * 0.55
+    # > Sommes revenant aux communes désignées dans la colonne 5
+    # au titre des 1ère et 2ème fractions
     # col. 14
-    matrice_1404_sip["1ère fraction (b)"] = matrice_1404_sip["1ère fraction (col. 10 x 35%)"]
+    matrice_1404_sip["1ère fraction (b)"] = matrice_1404_sip[
+        "1ère fraction (col. 10 x 35%)"
+        ]
     # col. 15
-    matrice_1404_sip["2ème fraction (a)"] = matrice_1404_sip["2ème fraction (col. 10 x 10%)"]
-    matrice_1404_sip["Total (col. 14 + col. 15)"] = matrice_1404_sip["1ère fraction (b)"] + \
-        matrice_1404_sip["2ème fraction (a)"]
+    matrice_1404_sip["2ème fraction (a)"] = matrice_1404_sip[
+        "2ème fraction (col. 10 x 10%)"
+        ]
+    matrice_1404_sip["Total (col. 14 + col. 15)"] = matrice_1404_sip[
+        "1ère fraction (b)"
+        ] + matrice_1404_sip["2ème fraction (a)"]
 
     # TAXE MINIÈRE SUR L'OR DE GUYANE
     matrice_1404_sip["Produit net de la taxe"] = data_sip["taxe_guyane"].values
@@ -362,11 +400,12 @@ def generate_matrice_1404_sip(columns_1404, data_sip, sip_name):
 
 def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
     colonnes_1404 = [
-        "Service de la direction générale des finances publiques en charge du recouvrement",  # SIP
+        "Service de la direction générale des finances publiques en charge du recouvrement",  # SIP  # noqa: E501
         "Articles des rôles",
         "Désignation des exploitants",
 
-        # DEPARTEMENTS ET COMMUNES sur les territoires desquels fonctionnent les exploitations :
+        # DEPARTEMENTS ET COMMUNES
+        # sur les territoires desquels fonctionnent les exploitations :
         "Départements",  # col. 4
         "Communes",  # col. 5
 
@@ -384,7 +423,8 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
         "1ère fraction (col. 10 x 35%)",
         "2ème fraction (col. 10 x 10%)",
         "3ème fraction (col. 10 x 55%)",
-        # > Sommes revenant aux communes désignées dans la colonne 5 au titre des 1ère et 2ème fractions
+        # > Sommes revenant aux communes désignées dans la colonne 5
+        # au titre des 1ère et 2ème fractions
         "1ère fraction (b)",  # col. 14
         "2ème fraction (a)",  # col. 15
         "Total (col. 14 + col. 15)",
@@ -410,7 +450,7 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
     matrice_1404_sip_cayenne = generate_matrice_1404_sip(
         colonnes_1404, data_sip_cayenne, sip_guyane_cayenne_nom)
     matrice_1404_sip_cayenne.to_csv(
-        f'matrice_1404_sip_guyane_cayenne_production_{annee_production}_{timestamp}.csv',
+        f'matrice_1404_sip_guyane_cayenne_production_{annee_production}_{timestamp}.csv',  # noqa: E501
         index=False,
         sep=';',
         encoding='utf-8',
@@ -430,11 +470,14 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
         )
 
     data_sip_st_laurent_du_maroni = get_sip_data(
-        data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
+        data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni
+        )
     matrice_1404_sip_st_laurent_du_maroni = generate_matrice_1404_sip(
-        colonnes_1404, data_sip_st_laurent_du_maroni, sip_guyane_st_laurent_du_maroni_nom)
+        colonnes_1404, data_sip_st_laurent_du_maroni,
+        sip_guyane_st_laurent_du_maroni_nom
+        )
     matrice_1404_sip_st_laurent_du_maroni.to_csv(
-        f'matrice_1404_sip_guyane_st_laurent_du_maroni_production_{annee_production}_{timestamp}.csv',
+        f'matrice_1404_sip_guyane_st_laurent_du_maroni_production_{annee_production}_{timestamp}.csv',  # noqa: E501
         index=False,
         sep=';',
         encoding='utf-8',

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -225,61 +225,71 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
         "Taxe minière sur l'or de Guyane",  # Produit net = col. 4
         "Sommes revenant à Région de Guyane",
         "Sommes revenant à Conservatoire de biodiversité",  # Rien en 2020 ?
-        
+
         # Sommes revenant à l'État :
         "Frais d'assiette et de recouvrement",  # = col. 7
         "Dégrèvements et non-valeurs",  # col. 8 / Rien en 2020 ?
-        "Total des colonnes 7 et 8", # col. 9
+        "Total des colonnes 7 et 8",  # col. 9
         "Total des colonnes 2, 3 ,4 et 9",
         "Nombre d'articles des rôles"
-    ]
+        ]
 
     matrice_1403 = pandas.DataFrame(columns = colonnes_1403)
 
-    data_sip_cayenne = get_sip_data(data, "commune_exploitation_principale", sip_guyane_cayenne)
-    data_sip_kourou = get_sip_data(data, "commune_exploitation_principale", sip_guyane_kourou)
-    data_sip_st_laurent_du_maroni = get_sip_data(data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
+    data_sip_cayenne = get_sip_data(
+        data, "commune_exploitation_principale", sip_guyane_cayenne)
+    data_sip_kourou = get_sip_data(
+        data, "commune_exploitation_principale", sip_guyane_kourou)
+    data_sip_st_laurent_du_maroni = get_sip_data(
+        data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
 
     matrice_1403["Service de la Direction générale des finances publiques en charge du recouvrement"] = [
         sip_guyane_cayenne_nom,
         sip_guyane_kourou_nom,
         sip_guyane_st_laurent_du_maroni_nom
-    ]
+        ]
 
     matrice_1403["Redevance départementale"] = [
-        data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"].sum().astype(int),
-        data_sip_kourou["redevance_departementale_des_mines_aurifere_kg"].sum().astype(int),
-        data_sip_st_laurent_du_maroni["redevance_departementale_des_mines_aurifere_kg"].sum().astype(int)
-    ]
+        data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"].sum().astype(
+            int),
+        data_sip_kourou["redevance_departementale_des_mines_aurifere_kg"].sum().astype(
+            int),
+        data_sip_st_laurent_du_maroni["redevance_departementale_des_mines_aurifere_kg"].sum(
+            ).astype(int)
+        ]
 
     matrice_1403["Redevance communale"] = [
         data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
         data_sip_kourou["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
-        data_sip_st_laurent_du_maroni["redevance_communale_des_mines_aurifere_kg"].sum().astype(int)
-    ]
+        data_sip_st_laurent_du_maroni["redevance_communale_des_mines_aurifere_kg"].sum().astype(
+            int)
+        ]
     matrice_1403["Taxe minière sur l'or de Guyane"] = [
         data_sip_cayenne["taxe_guyane"].sum().astype(int),
         data_sip_kourou["taxe_guyane"].sum().astype(int),
         data_sip_st_laurent_du_maroni["taxe_guyane"].sum().astype(int)
-    ]
+        ]
 
     total_rdcm_taxe = (
-        matrice_1403["Redevance départementale"] 
-        + matrice_1403["Redevance communale"] 
+        matrice_1403["Redevance départementale"]
+        + matrice_1403["Redevance communale"]
         + matrice_1403["Taxe minière sur l'or de Guyane"]
         )
 
     matrice_1403["Sommes revenant à Région de Guyane"] = matrice_1403["Taxe minière sur l'or de Guyane"]
     matrice_1403["Sommes revenant à Conservatoire de biodiversité"] = [None, None, None]
-    matrice_1403["Frais d'assiette et de recouvrement"] = (total_rdcm_taxe * 0.08).astype(int)  # 4.4% mais à 8% en 2020, perte des centimes
-    matrice_1403["Dégrèvements et non-valeurs"] = [None, None, None]  # 3.6% mais vide en 2020
+    matrice_1403["Frais d'assiette et de recouvrement"] = (
+        total_rdcm_taxe * 0.08).astype(int)  # 4.4% mais à 8% en 2020, perte des centimes
+    matrice_1403["Dégrèvements et non-valeurs"] = [None,
+        None, None]  # 3.6% mais vide en 2020
     matrice_1403["Total des colonnes 7 et 8"] = matrice_1403["Frais d'assiette et de recouvrement"]
-    matrice_1403["Total des colonnes 2, 3 ,4 et 9"] = total_rdcm_taxe + matrice_1403["Total des colonnes 7 et 8"]
+    matrice_1403["Total des colonnes 2, 3 ,4 et 9"] = total_rdcm_taxe + \
+        matrice_1403["Total des colonnes 7 et 8"]
     matrice_1403["Nombre d'articles des rôles"] = [
         data_sip_cayenne["nom_entreprise"].nunique(),
         data_sip_kourou["nom_entreprise"].nunique(),
         data_sip_st_laurent_du_maroni["nom_entreprise"].nunique()
-    ]
+        ]
 
     matrice_1403.to_csv(
         f'matrice_1403_drfip_guyane_production_{annee_production}_{timestamp}.csv',
@@ -294,41 +304,51 @@ def generate_matrice_1404_sip(columns_1404, data_sip, sip_name):
     matrice_1404_sip = pandas.DataFrame(columns = columns_1404)
 
     NB_ROWS_SIP = len(data_sip)
-    
-    matrice_1404_sip["Service de la direction générale des finances publiques en charge du recouvrement"] = [sip_name] * NB_ROWS_SIP
+
+    matrice_1404_sip["Service de la direction générale des finances publiques en charge du recouvrement"] = [
+        sip_name] * NB_ROWS_SIP
     matrice_1404_sip["Articles des rôles"] = data_sip["titre_id"].index
-    
+
     # Avant affectation, on valide le bon alignement des articles à défaut d'index commun aux DataFrame
     exploitants_sip_cayenne = build_designations_entreprises(data_sip)
-    assert (matrice_1404_sip["Articles des rôles"].values == exploitants_sip_cayenne.index).all()
+    assert (matrice_1404_sip["Articles des rôles"].values
+            == exploitants_sip_cayenne.index).all()
     matrice_1404_sip["Désignation des exploitants"] = exploitants_sip_cayenne.values
 
     # DEPARTEMENTS ET COMMUNES sur les territoires desquels fonctionnent les exploitations :
     matrice_1404_sip["Départements"] = ['Guyane'] * NB_ROWS_SIP  # col. 4
-    matrice_1404_sip["Communes"] = data_sip["commune_exploitation_principale"].values  # col. 5
+    # col. 5
+    matrice_1404_sip["Communes"] = data_sip["commune_exploitation_principale"].values
 
     # ELEMENTS SERVANT DE BASE A LA REPARTITION pour chaque exploitation :
-    matrice_1404_sip["Revenus imposables à la TFPB (état 1123, col. 3)"] = [None] * NB_ROWS_SIP  # vide en drfip
+    matrice_1404_sip["Revenus imposables à la TFPB (état 1123, col. 3)"] = [
+        None] * NB_ROWS_SIP  # vide en drfip
 
     # Avant affectation, on valide le bon alignement des articles à défaut d'index commun aux DataFrame
     production_communale = calculate_production_communale(data_sip)
-    assert (matrice_1404_sip["Articles des rôles"].values == production_communale.index).all()
+    assert (matrice_1404_sip["Articles des rôles"].values
+            == production_communale.index).all()
     matrice_1404_sip["Tonnages extraits :"] = production_communale.values
 
     # REDEVANCE DÉPARTEMENTALE :
     matrice_1404_sip["Produit net de la redevance (RDM)"] = data_sip["redevance_departementale_des_mines_aurifere_kg"].values
-    matrice_1404_sip["Sommes revenant aux départements désignés dans la colonne 4 (a)"] = matrice_1404_sip["Produit net de la redevance (RDM)"]
+    matrice_1404_sip["Sommes revenant aux départements désignés dans la colonne 4 (a)"] = matrice_1404_sip[
+        "Produit net de la redevance (RDM)"]
 
     # REDEVANCE COMMUNALE :
-    matrice_1404_sip["Produit net de la redevance (RCM)"] = data_sip["redevance_communale_des_mines_aurifere_kg"].values  # col. 10
+    # col. 10
+    matrice_1404_sip["Produit net de la redevance (RCM)"] = data_sip["redevance_communale_des_mines_aurifere_kg"].values
     # > Répartition
     matrice_1404_sip["1ère fraction (col. 10 x 35%)"] = matrice_1404_sip["Produit net de la redevance (RCM)"] * 0.35
     matrice_1404_sip["2ème fraction (col. 10 x 10%)"] = matrice_1404_sip["Produit net de la redevance (RCM)"] * 0.1
     matrice_1404_sip["3ème fraction (col. 10 x 55%)"] = matrice_1404_sip["Produit net de la redevance (RCM)"] * 0.55
     # > Sommes revenant aux communes désignées dans la colonne 5 au titre des 1ère et 2ème fractions
-    matrice_1404_sip["1ère fraction (b)"] = matrice_1404_sip["1ère fraction (col. 10 x 35%)"]  # col. 14
-    matrice_1404_sip["2ème fraction (a)"] = matrice_1404_sip["2ème fraction (col. 10 x 10%)"]  # col. 15
-    matrice_1404_sip["Total (col. 14 + col. 15)"] = matrice_1404_sip["1ère fraction (b)"] + matrice_1404_sip["2ème fraction (a)"]
+    # col. 14
+    matrice_1404_sip["1ère fraction (b)"] = matrice_1404_sip["1ère fraction (col. 10 x 35%)"]
+    # col. 15
+    matrice_1404_sip["2ème fraction (a)"] = matrice_1404_sip["2ème fraction (col. 10 x 10%)"]
+    matrice_1404_sip["Total (col. 14 + col. 15)"] = matrice_1404_sip["1ère fraction (b)"] + \
+        matrice_1404_sip["2ème fraction (a)"]
 
     # TAXE MINIÈRE SUR L'OR DE GUYANE
     matrice_1404_sip["Produit net de la taxe"] = data_sip["taxe_guyane"].values
@@ -375,18 +395,20 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
         "Région de Guyane",
         "Conservatoire",  # vide en 2020
         "Observations"
-    ]
-    # où : 
+        ]
+    # où :
     # (a) Attributions faites au prorata des tonnages indiqués dans la colonne 7.
     # (b) Attributions faites au prorata des revenus indiqués dans la colonne 6.
-    # (c) Le produit net de la taxe sur l'or de Guyane est affecté en totalité 
+    # (c) Le produit net de la taxe sur l'or de Guyane est affecté en totalité
     # à la région de Guyane en l'absence de création du conservatoire
     # (d) Dès que la création du conservatoire sera intervenu le produit de la taxe
-    # due par les PME sera réparti à parts égales entre la région Guyane 
+    # due par les PME sera réparti à parts égales entre la région Guyane
     # et cet organisme et la taxe due par les autres
 
-    data_sip_cayenne = get_sip_data(data, "commune_exploitation_principale", sip_guyane_cayenne)
-    matrice_1404_sip_cayenne = generate_matrice_1404_sip(colonnes_1404, data_sip_cayenne, sip_guyane_cayenne_nom)
+    data_sip_cayenne = get_sip_data(
+        data, "commune_exploitation_principale", sip_guyane_cayenne)
+    matrice_1404_sip_cayenne = generate_matrice_1404_sip(
+        colonnes_1404, data_sip_cayenne, sip_guyane_cayenne_nom)
     matrice_1404_sip_cayenne.to_csv(
         f'matrice_1404_sip_guyane_cayenne_production_{annee_production}_{timestamp}.csv',
         index=False,
@@ -394,9 +416,11 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
         encoding='utf-8',
         decimal=','
         )
-    
-    data_sip_kourou = get_sip_data(data, "commune_exploitation_principale", sip_guyane_kourou)
-    matrice_1404_sip_kourou = generate_matrice_1404_sip(colonnes_1404, data_sip_kourou, sip_guyane_kourou_nom)
+
+    data_sip_kourou = get_sip_data(
+        data, "commune_exploitation_principale", sip_guyane_kourou)
+    matrice_1404_sip_kourou = generate_matrice_1404_sip(
+        colonnes_1404, data_sip_kourou, sip_guyane_kourou_nom)
     matrice_1404_sip_kourou.to_csv(
         f'matrice_1404_sip_guyane_kourou_production_{annee_production}_{timestamp}.csv',
         index=False,
@@ -405,8 +429,10 @@ def generate_matrices_1404_drfip_guyane(data, annee_production, timestamp):
         decimal=','
         )
 
-    data_sip_st_laurent_du_maroni = get_sip_data(data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
-    matrice_1404_sip_st_laurent_du_maroni = generate_matrice_1404_sip(colonnes_1404, data_sip_st_laurent_du_maroni, sip_guyane_st_laurent_du_maroni_nom)
+    data_sip_st_laurent_du_maroni = get_sip_data(
+        data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
+    matrice_1404_sip_st_laurent_du_maroni = generate_matrice_1404_sip(
+        colonnes_1404, data_sip_st_laurent_du_maroni, sip_guyane_st_laurent_du_maroni_nom)
     matrice_1404_sip_st_laurent_du_maroni.to_csv(
         f'matrice_1404_sip_guyane_st_laurent_du_maroni_production_{annee_production}_{timestamp}.csv',
         index=False,

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -1,7 +1,7 @@
 import numpy
 import pandas  # noqa: I201
 
-from sip import *
+from simulations.sip import *
 
 
 def build_designations_entreprises(data):
@@ -301,15 +301,15 @@ def generate_matrice_1404_drfip_guyane(data, annee_production, timestamp):
         "Communes",  # col. 5
 
         # ELEMENTS SERVANT DE BASE A LA REPARTITION pour chaque exploitation :
-        "Revenus imposables à la TFPB (état 1123, col. 3)",  # vide en drfip
-        "Tonnages extraits :",
+        "Revenus imposables à la TFPB (état 1123, col. 3)",  # col. 6 / vide en drfip
+        "Tonnages extraits :",  # col. 7
 
         # REDEVANCE DÉPARTEMENTALE :
-        "Produit net de la redevance",
+        "Produit net de la redevance (RDM)",
         "Sommes revenant aux départements désignés dans la colonne 4 (a)",
 
         # REDEVANCE COMMUNALE :
-        "Produit net de la redevance",  # col. 10
+        "Produit net de la redevance (RCM)",  # col. 10
         # > Répartition
         "1ère fraction (col. 10 x 35%)",
         "2ème fraction (col. 10 x 10%)",
@@ -326,8 +326,59 @@ def generate_matrice_1404_drfip_guyane(data, annee_production, timestamp):
         "Conservatoire",  # vide en 2020
         "Observations"
     ]
+    # où : 
+    # (a) Attributions faites au prorata des tonnages indiqués dans la colonne 7.
+    # (b) Attributions faites au prorata des revenus indiqués dans la colonne 6.
+    # (c) Le produit net de la taxe sur l'or de Guyane est affecté en totalité 
+    # à la région de Guyane en l'absence de création du conservatoire
+    # (d) Dès que la création du conservatoire sera intervenu le produit de la taxe
+    # due par les PME sera réparti à parts égales entre la région Guyane 
+    # et cet organisme et la taxe due par les autres
 
     matrice_1404 = pandas.DataFrame(columns = colonnes_1404)
+
+    data_sip_cayenne = get_sip_data(data, "commune_exploitation_principale", sip_guyane_cayenne)
+    NB_ROWS_SIP_CAYENNE = len(data_sip_cayenne)
+    data_sip_kourou = get_sip_data(data, "commune_exploitation_principale", sip_guyane_kourou)
+    data_sip_st_laurent_du_maroni = get_sip_data(data, "commune_exploitation_principale", sip_guyane_st_laurent_du_maroni)
+    
+    matrice_1404["Service de la direction générale des finances publiques en charge du recouvrement"] = [sip_guyane_cayenne_nom] * NB_ROWS_SIP_CAYENNE
+    matrice_1404["Articles des rôles"] = data_sip_cayenne["titre_id"].index
+
+    exploitants_sip_cayenne = build_designations_entreprises(data_sip_cayenne)
+    print("exploitants_sip_cayenne", exploitants_sip_cayenne)
+    matrice_1404["Désignation des exploitants"] = exploitants_sip_cayenne
+
+    # DEPARTEMENTS ET COMMUNES sur les territoires desquels fonctionnent les exploitations :
+    matrice_1404["Départements"] = ['Guyane'] * NB_ROWS_SIP_CAYENNE  # col. 4
+    matrice_1404["Communes"] = data_sip_cayenne["commune_exploitation_principale"]  # col. 5
+
+    # ELEMENTS SERVANT DE BASE A LA REPARTITION pour chaque exploitation :
+    matrice_1404["Revenus imposables à la TFPB (état 1123, col. 3)"] = [None] * NB_ROWS_SIP_CAYENNE  # vide en drfip
+    matrice_1404["Tonnages extraits :"] = calculate_production_communale(data_sip_cayenne)
+
+    # REDEVANCE DÉPARTEMENTALE :
+    matrice_1404["Produit net de la redevance (RDM)"] = data_sip_cayenne["redevance_departementale_des_mines_aurifere_kg"]
+    matrice_1404["Sommes revenant aux départements désignés dans la colonne 4 (a)"] = matrice_1404["Produit net de la redevance (RDM)"]
+
+    # REDEVANCE COMMUNALE :
+    matrice_1404["Produit net de la redevance (RCM)"] = data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"]  # col. 10
+    # > Répartition
+    matrice_1404["1ère fraction (col. 10 x 35%)"] = matrice_1404["Produit net de la redevance (RCM)"] * 0.35
+    matrice_1404["2ème fraction (col. 10 x 10%)"] = matrice_1404["Produit net de la redevance (RCM)"] * 0.1
+    matrice_1404["3ème fraction (col. 10 x 55%)"] = matrice_1404["Produit net de la redevance (RCM)"] * 0.55
+    # > Sommes revenant aux communes désignées dans la colonne 5 au titre des 1ère et 2ème fractions
+    matrice_1404["1ère fraction (b)"] = matrice_1404["1ère fraction (col. 10 x 35%)"]  # col. 14
+    matrice_1404["2ème fraction (a)"] = matrice_1404["2ème fraction (col. 10 x 10%)"]  # col. 15
+    matrice_1404["Total (col. 14 + col. 15)"] = matrice_1404["1ère fraction (b)"] + matrice_1404["2ème fraction (a)"]
+
+    # TAXE MINIÈRE SUR L'OR DE GUYANE
+    matrice_1404["Produit net de la taxe"] = data_sip_cayenne["taxe_guyane"]
+    # > Répartition
+    matrice_1404["Région de Guyane"] = matrice_1404["Produit net de la taxe"]
+    matrice_1404["Conservatoire"] = [None] * NB_ROWS_SIP_CAYENNE  # vide en 2020
+    matrice_1404["Observations"] = [None] * NB_ROWS_SIP_CAYENNE    
+
     matrice_1404.to_csv(
         f'matrice_1404_drfip_guyane_production_{annee_production}_{timestamp}.csv',
         index=False,

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -276,9 +276,9 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
     matrice_1403["Total des colonnes 7 et 8"] = matrice_1403["Frais d'assiette et de recouvrement"]
     matrice_1403["Total des colonnes 2, 3 ,4 et 9"] = total_rdcm_taxe + matrice_1403["Total des colonnes 7 et 8"]
     matrice_1403["Nombre d'articles des rôles"] = [
-        len(data_sip_cayenne),
-        len(data_sip_kourou),
-        len(data_sip_st_laurent_du_maroni)
+        data_sip_cayenne["nom_entreprise"].nunique(),
+        data_sip_kourou["nom_entreprise"].nunique(),
+        data_sip_st_laurent_du_maroni["nom_entreprise"].nunique()
     ]
 
     matrice_1403.to_csv(

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -16,7 +16,7 @@ from simulations.drfip import (
     generate_matrice_annexe_drfip_guyane,
     generate_matrice_drfip_guyane,
     generate_matrice_1403_drfip_guyane,
-    generate_matrice_1404_drfip_guyane
+    generate_matrices_1404_drfip_guyane
     )
 
 
@@ -588,7 +588,7 @@ if __name__ == "__main__":
         timestamp
         )
 
-    generate_matrice_1404_drfip_guyane(
+    generate_matrices_1404_drfip_guyane(
         resultat, 
         data_period, 
         timestamp

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -12,6 +12,7 @@ from openfisca_core.simulation_builder import SimulationBuilder  # noqa: I100
 from openfisca_france_fiscalite_miniere import CountryTaxBenefitSystem as FranceFiscaliteMiniereTaxBenefitSystem  # noqa: E501
 from openfisca_france_fiscalite_miniere.variables.taxes import CategorieEnum
 
+from simulations.sip import sip_guyane_cayenne, sip_guyane_kourou, sip_guyane_st_laurent_du_maroni
 from simulations.drfip import (
     generate_matrice_annexe_drfip_guyane,
     generate_matrice_drfip_guyane,
@@ -258,6 +259,16 @@ def clean_data(data, data_period):
     # attention : on refait l'index du dataframe pour distinguer les lignes résultat.
     une_commune_par_titre = dispatch_titres_multicommunes(
         quantites_chiffrees, data_period)
+
+    communes_guyane = sip_guyane_cayenne+sip_guyane_kourou+sip_guyane_st_laurent_du_maroni
+    filtre_communes = une_commune_par_titre["commune_exploitation_principale"].isin(communes_guyane) 
+    une_commune_par_titre = une_commune_par_titre.loc[filtre_communes]
+
+    assert une_commune_par_titre["commune_exploitation_principale"].isin(
+        communes_guyane
+        ).all(), une_commune_par_titre.loc[
+            ~une_commune_par_titre["commune_exploitation_principale"].isin(communes_guyane)
+            ][["commune_exploitation_principale"]]
 
     return une_commune_par_titre
 

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -12,14 +12,17 @@ from openfisca_core.simulation_builder import SimulationBuilder  # noqa: I100
 from openfisca_france_fiscalite_miniere import CountryTaxBenefitSystem as FranceFiscaliteMiniereTaxBenefitSystem  # noqa: E501
 from openfisca_france_fiscalite_miniere.variables.taxes import CategorieEnum
 
-from simulations.sip import sip_guyane_cayenne, sip_guyane_kourou, sip_guyane_st_laurent_du_maroni
-from simulations.drfip import (
-    generate_matrice_annexe_drfip_guyane,
+from simulations.drfip import (  # noqa: I101
     generate_matrice_drfip_guyane,
+    generate_matrice_annexe_drfip_guyane,
     generate_matrice_1403_drfip_guyane,
     generate_matrices_1404_drfip_guyane
     )
-
+from simulations.sip import (
+    sip_guyane_cayenne,
+    sip_guyane_kourou,
+    sip_guyane_st_laurent_du_maroni
+    )
 
 COLONNE_OR_2019 = "renseignements_orNet"
 COLONNE_OR_2020 = "substancesFiscales_auru"  # ou "renseignements_orExtrait" ?
@@ -260,7 +263,11 @@ def clean_data(data, data_period):
     une_commune_par_titre = dispatch_titres_multicommunes(
         quantites_chiffrees, data_period)
 
-    communes_guyane = sip_guyane_cayenne + sip_guyane_kourou + sip_guyane_st_laurent_du_maroni
+    communes_guyane = (
+        sip_guyane_cayenne
+        + sip_guyane_kourou
+        + sip_guyane_st_laurent_du_maroni
+        )
     filtre_communes = une_commune_par_titre["commune_exploitation_principale"].isin(
         communes_guyane)
     une_commune_par_titre = une_commune_par_titre.loc[filtre_communes]

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -14,7 +14,8 @@ from openfisca_france_fiscalite_miniere.variables.taxes import CategorieEnum
 
 from simulations.drfip import (
     generate_matrice_annexe_drfip_guyane,
-    generate_matrice_drfip_guyane
+    generate_matrice_drfip_guyane,
+    generate_matrice_1403_drfip_guyane
     )
 
 
@@ -577,5 +578,11 @@ if __name__ == "__main__":
     generate_matrice_annexe_drfip_guyane(
         resultat,
         data_period,
+        timestamp
+        )
+
+    generate_matrice_1403_drfip_guyane(
+        resultat, 
+        data_period, 
         timestamp
         )

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -15,7 +15,8 @@ from openfisca_france_fiscalite_miniere.variables.taxes import CategorieEnum
 from simulations.drfip import (
     generate_matrice_annexe_drfip_guyane,
     generate_matrice_drfip_guyane,
-    generate_matrice_1403_drfip_guyane
+    generate_matrice_1403_drfip_guyane,
+    generate_matrice_1404_drfip_guyane
     )
 
 
@@ -582,6 +583,12 @@ if __name__ == "__main__":
         )
 
     generate_matrice_1403_drfip_guyane(
+        resultat, 
+        data_period, 
+        timestamp
+        )
+
+    generate_matrice_1404_drfip_guyane(
         resultat, 
         data_period, 
         timestamp

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -260,14 +260,16 @@ def clean_data(data, data_period):
     une_commune_par_titre = dispatch_titres_multicommunes(
         quantites_chiffrees, data_period)
 
-    communes_guyane = sip_guyane_cayenne+sip_guyane_kourou+sip_guyane_st_laurent_du_maroni
-    filtre_communes = une_commune_par_titre["commune_exploitation_principale"].isin(communes_guyane) 
+    communes_guyane = sip_guyane_cayenne + sip_guyane_kourou + sip_guyane_st_laurent_du_maroni
+    filtre_communes = une_commune_par_titre["commune_exploitation_principale"].isin(
+        communes_guyane)
     une_commune_par_titre = une_commune_par_titre.loc[filtre_communes]
 
     assert une_commune_par_titre["commune_exploitation_principale"].isin(
         communes_guyane
         ).all(), une_commune_par_titre.loc[
-            ~une_commune_par_titre["commune_exploitation_principale"].isin(communes_guyane)
+            ~une_commune_par_titre["commune_exploitation_principale"].isin(
+                communes_guyane)
             ][["commune_exploitation_principale"]]
 
     return une_commune_par_titre
@@ -594,13 +596,13 @@ if __name__ == "__main__":
         )
 
     generate_matrice_1403_drfip_guyane(
-        resultat, 
-        data_period, 
+        resultat,
+        data_period,
         timestamp
         )
 
     generate_matrices_1404_drfip_guyane(
-        resultat, 
-        data_period, 
+        resultat,
+        data_period,
         timestamp
         )

--- a/simulations/sip.py
+++ b/simulations/sip.py
@@ -17,7 +17,7 @@ sip_guyane_st_laurent_du_maroni_nom = "SIP de Saint-Laurent du Maroni"
 sip_guyane_st_laurent_du_maroni: List[str] = [
     "Papaichton", "Apatou", "Awala-Yalimapo",
     "Grand-Santi", "Mana", "Saül", "Maripasoula",
-    "Saint-Laurent du Maroni"
+    "Saint-Laurent-du-Maroni"
     ]
 
 def get_sip_data(data, column_name, sip):

--- a/simulations/sip.py
+++ b/simulations/sip.py
@@ -23,5 +23,5 @@ sip_guyane_st_laurent_du_maroni: List[str] = [
 
 
 def get_sip_data(data, column_name, sip):
-    filter = data[column_name].isin(sip)
+    filter = data[column_name].isin(sip)  # noqa: A001
     return data[filter]

--- a/simulations/sip.py
+++ b/simulations/sip.py
@@ -6,12 +6,13 @@ from typing import List
 sip_guyane_cayenne_nom = "SIP de Cayenne"
 sip_guyane_cayenne: List[str] = [
     "Montsinery-Tonnegrande", "Ouanary", "Camopi", "Cayenne",
-    "Régina", "Remire-Montjoly", "Roura", 
+    "Régina", "Remire-Montjoly", "Roura",
     "Saint-Georges", "Matoury"
     ]
 
 sip_guyane_kourou_nom = "SIP de Kourou"
-sip_guyane_kourou: List[str] = ["Kourou", "Macouria", "Iracoubo", "Sinnamary", "Saint-Élie"]
+sip_guyane_kourou: List[str] = ["Kourou", "Macouria",
+    "Iracoubo", "Sinnamary", "Saint-Élie"]
 
 sip_guyane_st_laurent_du_maroni_nom = "SIP de Saint-Laurent du Maroni"
 sip_guyane_st_laurent_du_maroni: List[str] = [
@@ -19,6 +20,7 @@ sip_guyane_st_laurent_du_maroni: List[str] = [
     "Grand-Santi", "Mana", "Saül", "Maripasoula",
     "Saint-Laurent-du-Maroni"
     ]
+
 
 def get_sip_data(data, column_name, sip):
     filter = data[column_name].isin(sip)

--- a/simulations/sip.py
+++ b/simulations/sip.py
@@ -1,0 +1,25 @@
+# SIP = services des impôts des particuliers
+
+from typing import List
+
+
+sip_guyane_cayenne_nom = "SIP de Cayenne"
+sip_guyane_cayenne: List[str] = [
+    "Montsinery-Tonnegrande", "Ouanary", "Camopi", "Cayenne",
+    "Régina", "Remire-Montjoly", "Roura", 
+    "Saint-Georges", "Matoury"
+    ]
+
+sip_guyane_kourou_nom = "SIP de Kourou"
+sip_guyane_kourou: List[str] = ["Kourou", "Macouria", "Iarcoubo", "Sinnamary", "Saint-Elie"]
+
+sip_guyane_st_laurent_du_maroni_nom = "SIP de Saint-Laurent du Maroni"
+sip_guyane_st_laurent_du_maroni: List[str] = [
+    "Papaichton", "Apatou", "Awala-Yalimapo",
+    "Grand-Santi", "Mana", "Saül", "Maripasoula",
+    "Saint-Laurent du Maroni"
+    ]
+
+def get_sip_data(data, column_name, sip):
+    filter = data[column_name].isin(sip)
+    return data[filter]

--- a/simulations/sip.py
+++ b/simulations/sip.py
@@ -11,7 +11,7 @@ sip_guyane_cayenne: List[str] = [
     ]
 
 sip_guyane_kourou_nom = "SIP de Kourou"
-sip_guyane_kourou: List[str] = ["Kourou", "Macouria", "Iarcoubo", "Sinnamary", "Saint-Elie"]
+sip_guyane_kourou: List[str] = ["Kourou", "Macouria", "Iracoubo", "Sinnamary", "Saint-Élie"]
 
 sip_guyane_st_laurent_du_maroni_nom = "SIP de Saint-Laurent du Maroni"
 sip_guyane_st_laurent_du_maroni: List[str] = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2020.
* Zones impactées : 
  - `simulations/drfip.py`
  - `simulations/estime_taxes_redevances.py`
* Détails :
  - Ajoute la génération des matrices 1403 et 1404 aux scripts de `simulations/`.
  - Matrices au format 2021. Code exécuté sur données de production 2020.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France — Fiscalité Minière (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
