### PR TITLE
Corrige la taxe aurifère suite à l'évolution des entités

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 3.0.2 [#26](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/26)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `./variables/taxes.py`
+* Détails :
+  - Corrige l'erreur d'entité à l'appel de `taxe_guyane_brute` et `taxe_guyane_deduction`
+
 ### 3.0.1 [#25](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/25)
 
 * Correction d'un crash.

--- a/openfisca_france_fiscalite_miniere/tests/test_taxe_aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_taxe_aurifere.yaml
@@ -1,12 +1,55 @@
-- name: Répartition de la taxe aurifère 
+- name: Taxe aurifère selon production de l'année passée
   period: 2020
   input:
-    surface_communale: 1
-    surface_totale: 1
     quantite_aurifere_kg: 1000
-    taxe_guyane_deduction: 0
+    surface_communale: 1
+    surface_totale: 2
+    taxe_guyane_deduction: 
+      2021: 10
   output:
     taxe_guyane_brute:
-      2021: 498.06 * 1000
+      2021: 498.06 * 1000 * 1 / 2  # PME par défaut.
     taxe_guyane:
-      2021 : 498.06 * 1000
+      2021 : (498.06 * 1000 * 1 / 2) - 10
+
+- name: Taxe aurifère selon catégorie de l'entreprise du titre et surface communale
+  period: 2020
+  input:
+    articles:
+      a1:
+        quantite_aurifere_kg: 10
+        surface_communale: 0.5
+        surface_totale: 1
+      a2:
+        quantite_aurifere_kg: 100
+        surface_communale: 0.5
+        surface_totale: 1
+      a3:
+        quantite_aurifere_kg: 1000
+        surface_communale: 2
+        surface_totale: 2
+    titres:
+      t1:
+        articles: ['a1', 'a2']
+        categorie: pme
+        investissement: 20
+      t2:
+        articles: 'a3'
+        categorie: autre
+        investissement: 40
+    communes:
+      c1:
+        articles: 'a1'
+      c2:
+        articles: ['a2', 'a3']
+  output:
+    taxe_guyane_deduction: 
+      2021: [10, 10, 40] # (20 * 0.5 / 1) OU (40 * 2 / 2)
+    taxe_guyane_brute: 
+      2021: [2_490.3, 24_903, 996_130] # tarif pme OU autre
+    taxe_guyane:
+      2021 : [
+        2_480.3,  # 498.06 * 10 * (0.5 / 1) - (20 * 0.5 / 1)
+        24_893,  # 498.06 * 100 * (0.5 / 1) - (20 * 0.5 / 1)
+        996_090  # 996.13 * 1000 * (2 / 2) - (40 * 2 / 2)
+        ]

--- a/openfisca_france_fiscalite_miniere/tests/test_taxe_aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_taxe_aurifere.yaml
@@ -1,0 +1,12 @@
+- name: Répartition de la taxe aurifère 
+  period: 2020
+  input:
+    surface_communale: 1
+    surface_totale: 1
+    quantite_aurifere_kg: 1000
+    taxe_guyane_deduction: 0
+  output:
+    taxe_guyane_brute:
+      2021: 498.06 * 1000
+    taxe_guyane:
+      2021 : 498.06 * 1000

--- a/openfisca_france_fiscalite_miniere/variables/taxes.py
+++ b/openfisca_france_fiscalite_miniere/variables/taxes.py
@@ -42,7 +42,7 @@ class taxe_guyane_brute(Variable):
         annee_production = period.last_year
         params = parameters(period).taxes.guyane
         quantites = articles("quantite_aurifere_kg", annee_production)
-        categories = articles("categorie", annee_production).decode()
+        categories = articles.titre("categorie", annee_production).decode()
         tarifs = (params.categories[categorie.name] for categorie in categories)
         tarifs = numpy.fromiter(tarifs, dtype = float)
 
@@ -62,7 +62,7 @@ class taxe_guyane_brute(Variable):
         annee_production = period.last_year
         params = parameters(period).taxes.guyane
         quantites = articles("quantite_aurifere_kg", annee_production)
-        categories = articles("categorie", annee_production).decode()
+        categories = articles.titre("categorie", annee_production).decode()
         tarifs = (params.categories[categorie.name] for categorie in categories)
         tarifs = numpy.fromiter(tarifs, dtype = float)
 
@@ -79,7 +79,7 @@ class taxe_guyane_deduction(Variable):
     def formula_2020_01(articles, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
         params = parameters(period).taxes.guyane
-        investissements = articles("investissement", annee_production)
+        investissements = articles.titre("investissement", annee_production)
         taxes_brutes = articles("taxe_guyane_brute", period)
         taux_deduction = params.deductions.taux
         montant_deduction_max = params.deductions.montant
@@ -107,7 +107,7 @@ class taxe_guyane_deduction(Variable):
     def formula(articles, period, parameters) -> numpy.ndarray:
         annee_production = period.last_year
         params = parameters(period).taxes.guyane
-        investissements = articles("investissement", annee_production)
+        investissements = articles.titre("investissement", annee_production)
         taxes_brutes = articles("taxe_guyane_brute", period)
         taux_deduction = params.deductions.taux
         montant_deduction_max = params.deductions.montant

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="OpenFisca-France-Fiscalite-Miniere",
     version="3.0.1",
     author="OpenFisca Team",
-    author_email = "contact@openfisca.fr",
+    author_email = "contact@openfisca.org",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="3.0.1",
+    version="3.0.2",
     author="OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
Fixes #24 

~~⚠️ La branche de cette PR dépend du fix d'API Web pour permettre son test par calcul d'API.~~

* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `./variables/taxes.py`
* Détails :
  - Corrige l'erreur d'entité à l'appel de `taxe_guyane_brute` et `taxe_guyane_deduction`

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

