### PR TITLE
Uniformise les labels des quantités des substances fiscales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 4.2.0 [#29](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/29)
+
+* Uniformisation des noms des variables des redevances communales et departementales
+* Zones impactées :
+  - `variables/redevances_communales_*/*.py`
+  - `variables/frais.py`
+  - `variables/redevances.py`
+* Détails :
+  - Enlève l'unité dans le nom de la classe
+    - par exemple : `redevance_communale_des_mines_sel_raffine_kt` devient `redevance_communale_des_mines_sel_raffine`
+
 # 4.1.0 [#30](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/30)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france_fiscalite_miniere/__init__.py
+++ b/openfisca_france_fiscalite_miniere/__init__.py
@@ -13,7 +13,7 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
         self.add_variables_from_directory(os.path.join(COUNTRY_DIR, 'variables'))
         self.load_parameters(os.path.join(COUNTRY_DIR, 'parameters'))
         self.open_api_config = {
-            "variable_example": "redevance_communale_des_mines_aurifere_kg",
+            "variable_example": "redevance_communale_des_mines_aurifere",
             "parameter_example": "redevances.communales.aurifere",
             "simulation_example": examples.article,
             }

--- a/openfisca_france_fiscalite_miniere/examples/article.json
+++ b/openfisca_france_fiscalite_miniere/examples/article.json
@@ -5,7 +5,7 @@
                 "2019": 1000,
                 "2018": 1000
             },
-            "redevance_communale_des_mines_aurifere_kg": {
+            "redevance_communale_des_mines_aurifere": {
                 "2020": null,
                 "2019": null
             }

--- a/openfisca_france_fiscalite_miniere/examples/nouveau_format.json
+++ b/openfisca_france_fiscalite_miniere/examples/nouveau_format.json
@@ -7,16 +7,13 @@
             "surface_communale": {
                 "2021": 0.5
             },
-            "redevance_communale_des_mines_aurifere_kg": {
+            "redevance_communale_des_mines_aurifere": {
                 "2022": null
             }
         },
         "m-ax-lieu-dit-SEL-RAFFINE-COMMUNE1": {
             "quantite_sel_raffine_kt": {
                 "2021": 1000
-            },
-            "surface_totale": {
-                "2021": 0.5 
             }
         }
     },
@@ -35,7 +32,7 @@
                 "2021": "4500"
             },
             "surface_totale": {
-                "2021": 0.5 
+                "2021": 0.5
             },
             "articles": [
                 "m-ax-lieu-dit-OR-COMMUNE1",
@@ -48,7 +45,7 @@
             "articles": [
                 "m-ax-lieu-dit-OR-COMMUNE1",
                 "m-ax-lieu-dit-SEL-RAFFINE-COMMUNE1"
-            ]   
+            ]
         }
     }
 }

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
@@ -33,7 +33,7 @@
 
 # - name: "Minerais argentifères (par centaine de kilogrammes d'argent contenu)"
 #   input:
-#     quantite_argentifere_q:
+#     quantite_argentifere_100kg:
 #       2018: 100
 #       2017: 100
 #   output:
@@ -85,13 +85,13 @@
       2018: 100
       2017: 100
   output:
-    redevance_communale_des_mines_sel_abattage_kt:
+    redevance_communale_des_mines_sel_abattage:
       2019: 70800
       2018: 68740
-    redevance_departementale_des_mines_sel_abattage_kt:
+    redevance_departementale_des_mines_sel_abattage:
       2019: 14390
       2018: 13970
-    redevance_totale_des_mines_sel_abattage_kt:
+    redevance_totale_des_mines_sel_abattage:
       2019: 85190
       2018: 82710
 
@@ -101,13 +101,13 @@
       2018: 100
       2017: 100
   output:
-    redevance_communale_des_mines_sel_raffine_kt:
+    redevance_communale_des_mines_sel_raffine:
       2019: 43100
       2018: 41840
-    redevance_departementale_des_mines_sel_raffine_kt:
+    redevance_departementale_des_mines_sel_raffine:
       2019: 8500
       2018: 8250
-    redevance_totale_des_mines_sel_raffine_kt:
+    redevance_totale_des_mines_sel_raffine:
       2019: 51600
       2018: 50090
 
@@ -117,13 +117,13 @@
       2018: 100
       2017: 100
   output:
-    redevance_communale_des_mines_sel_dissolution_kt:
+    redevance_communale_des_mines_sel_dissolution:
       2019: 14390
       2018: 13970
-    redevance_departementale_des_mines_sel_dissolution_kt:
+    redevance_departementale_des_mines_sel_dissolution:
       2019: 2790
       2018: 2710
-    redevance_totale_des_mines_sel_dissolution_kt:
+    redevance_totale_des_mines_sel_dissolution:
       2019: 17180
       2018: 16680
 
@@ -132,25 +132,25 @@
   input:
     articles:
       societe_1:
-        redevance_communale_des_mines_sel_abattage_kt: 
+        redevance_communale_des_mines_sel_abattage:
           2019: 5
       societe_2:
-        redevance_communale_des_mines_sel_abattage_kt: 
+        redevance_communale_des_mines_sel_abattage:
           2019: 10
       societe_3:
-        redevance_communale_des_mines_sel_abattage_kt: 
+        redevance_communale_des_mines_sel_abattage:
           2019: 2
     communes:
       commune_1:
-        articles: 
+        articles:
         - societe_1
         - societe_2
       commune_2:
-        articles: 
+        articles:
         - societe_3
   output:
-    redevance_communale_totale_sel: 
-      2019: [15, 2]    
+    redevance_communale_totale_sel:
+      2019: [15, 2]
 
 
 # - name: "Charbon (par centaine de tonnes nettes extraites)"
@@ -494,13 +494,13 @@
 #       2018: 100
 #       2017: 100
 #   output:
-#     redevance_communale_des_mines_lithium_t:
+#     redevance_communale_des_mines_lithium_li20:
 #       2019: 4900
 #       2018: 4760
-#     redevance_departementale_des_mines_lithium_t:
+#     redevance_departementale_des_mines_lithium_li20:
 #       2019: 1000
 #       2018: 970
-#     redevance_totale_des_mines_lithium_t:
+#     redevance_totale_des_mines_lithium:
 #       2019: 5900
 #       2018: 5730
 

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances_auriferes.yaml
@@ -5,13 +5,13 @@
       2018: 100
       2017: 100
   output:
-    redevance_communale_des_mines_aurifere_kg:
+    redevance_communale_des_mines_aurifere:
       2019: 14970
       2018: 14530
-    redevance_departementale_des_mines_aurifere_kg:
+    redevance_departementale_des_mines_aurifere:
       2019: 2990
       2018: 2900
-    redevance_totale_des_mines_aurifere_kg:
+    redevance_totale_des_mines_aurifere:
       2019: 14970 + 2990
       2018: 14530 + 2900
 
@@ -19,15 +19,15 @@
   period: 2020
   absolute_error_margin: 0.01
   input:
-    surface_communale: 
+    surface_communale:
       2019: [0.1000, 10.0000]
-    surface_totale: 
+    surface_totale:
       2019: [10.1000, 10.1000]
-    quantite_aurifere_kg: 
+    quantite_aurifere_kg:
       2019: [2.000, 20.000]
   output:
     surface_communale_proportionnee:
       2019: [0.0099, 0.9901]
-    redevance_communale_des_mines_aurifere_kg: [3.0413, 3041.5872]  # tarif = 153.60
-    redevance_departementale_des_mines_aurifere_kg: [0.6079, 607.9214]  # tarif = 30.70
-    redevance_totale_des_mines_aurifere_kg: [3.6492, 3649.5086]
+    redevance_communale_des_mines_aurifere: [3.0413, 3041.5872]  # tarif = 153.60
+    redevance_departementale_des_mines_aurifere: [0.6079, 607.9214]  # tarif = 30.70
+    redevance_totale_des_mines_aurifere: [3.6492, 3649.5086]

--- a/openfisca_france_fiscalite_miniere/variables/frais.py
+++ b/openfisca_france_fiscalite_miniere/variables/frais.py
@@ -14,7 +14,7 @@ class fiscalite_frais_de_gestion_guyane(variables.Variable):
     definition_period = periods.YEAR
 
     def formula(articles, period, parameters) -> numpy.ndarray:
-        redevances = articles("redevance_totale_des_mines_aurifere_kg", period)
+        redevances = articles("redevance_totale_des_mines_aurifere", period)
         taxes = articles("taxe_guyane", period)
 
         parametres_frais = parameters(period).frais

--- a/openfisca_france_fiscalite_miniere/variables/redevances.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances.py
@@ -51,18 +51,18 @@ class redevance_communale_totale_sel(Variable):
     definition_period = YEAR
 
     def formula(communes, period) -> ndarray:
-        redevance_communale_des_mines_sel_abattage_kt = communes.members(
-            "redevance_communale_des_mines_sel_abattage_kt",
+        redevance_communale_des_mines_sel_abattage = communes.members(
+            "redevance_communale_des_mines_sel_abattage",
             period)
-        redevance_communale_des_mines_sel_raffine_kt = communes.members(
-            "redevance_communale_des_mines_sel_raffine_kt",
+        redevance_communale_des_mines_sel_raffine = communes.members(
+            "redevance_communale_des_mines_sel_raffine",
             period)
-        redevance_communale_des_mines_sel_dissolution_kt = communes.members(
-            "redevance_communale_des_mines_sel_dissolution_kt",
+        redevance_communale_des_mines_sel_dissolution = communes.members(
+            "redevance_communale_des_mines_sel_dissolution",
             period)
 
         return communes.sum(
-            redevance_communale_des_mines_sel_abattage_kt
-            + redevance_communale_des_mines_sel_raffine_kt
-            + redevance_communale_des_mines_sel_dissolution_kt
+            redevance_communale_des_mines_sel_abattage
+            + redevance_communale_des_mines_sel_raffine
+            + redevance_communale_des_mines_sel_dissolution
             )

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/argentifere.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/argentifere.py
@@ -6,7 +6,7 @@ from openfisca_core.variables import Variable
 from openfisca_france_fiscalite_miniere.entities import Article
 
 
-class quantite_argentifere_q(Variable):
+class quantite_argentifere_100kg(Variable):
     value_type = float
     entity = Article
     definition_period = YEAR
@@ -28,7 +28,7 @@ class redevance_communale_des_mines_argentifere(Variable):
         tarif_rcm = parameters(period).redevances.communales.argentifere
 
         annee_production = period.last_year
-        quantite = articles("quantite_argentifere_q", annee_production)
+        quantite = articles("quantite_argentifere_100kg", annee_production)
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
 
@@ -50,7 +50,7 @@ class redevance_departementale_des_mines_argentifere(Variable):
         tarif_rdm = parameters(period).redevances.departementales.argentifere
 
         annee_production = period.last_year
-        quantite = articles("quantite_argentifere_q", annee_production)
+        quantite = articles("quantite_argentifere_100kg", annee_production)
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
 

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/aurifere.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/aurifere.py
@@ -24,7 +24,7 @@ class quantite_aurifere_kg(Variable):
     '''
 
 
-class redevance_communale_des_mines_aurifere_kg(Variable):
+class redevance_communale_des_mines_aurifere(Variable):
     value_type = float
     entity = Article
     label = "Redevance communale des mines pour le minerais aurifères"
@@ -65,7 +65,7 @@ class redevance_communale_des_mines_aurifere_kg(Variable):
         return round(quantite * tarif, decimals = 2)
 
 
-class redevance_departementale_des_mines_aurifere_kg(Variable):
+class redevance_departementale_des_mines_aurifere(Variable):
     value_type = float
     entity = Article
     label = "Redevance départementale des mines pour le minerais aurifères"
@@ -97,7 +97,7 @@ class redevance_departementale_des_mines_aurifere_kg(Variable):
         return round(quantite * tarif, decimals = 2)
 
 
-class redevance_totale_des_mines_aurifere_kg(Variable):
+class redevance_totale_des_mines_aurifere(Variable):
     value_type = float
     entity = Article
     label = "Redevance départamentale + communale des mines"
@@ -105,9 +105,9 @@ class redevance_totale_des_mines_aurifere_kg(Variable):
 
     def formula(articles, period) -> ndarray:
         departementale = articles(
-            "redevance_departementale_des_mines_aurifere_kg",
+            "redevance_departementale_des_mines_aurifere",
             period)
         communale = articles(
-            "redevance_communale_des_mines_aurifere_kg",
+            "redevance_communale_des_mines_aurifere",
             period)
         return departementale + communale

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/lithium.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/lithium.py
@@ -6,7 +6,7 @@ from openfisca_core.variables import Variable
 from openfisca_france_fiscalite_miniere.entities import Article
 
 
-class quantite_lithium_kli2O(Variable):
+class quantite_lithium_li2O_t(Variable):
     value_type = float
     entity = Article
     definition_period = YEAR
@@ -14,7 +14,7 @@ class quantite_lithium_kli2O(Variable):
     reference = "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006294877/2020-03-25"  # noqa: E501
 
 
-class redevance_communale_des_mines_lithium(Variable):
+class redevance_communale_des_mines_lithium_li20(Variable):
     value_type = float
     entity = Article
     definition_period = YEAR
@@ -29,7 +29,7 @@ class redevance_communale_des_mines_lithium(Variable):
 
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
-        quantite = articles("quantite_lithium_kli2O", annee_production)
+        quantite = articles("quantite_lithium_li2O_t", annee_production)
 
         tarif_rcm = parameters(period).redevances.communales.lithium
 
@@ -37,7 +37,7 @@ class redevance_communale_des_mines_lithium(Variable):
         return round(rcm, decimals = 2)
 
 
-class redevance_departementale_des_mines_lithium(Variable):
+class redevance_departementale_des_mines_lithium_li20(Variable):
     value_type = float
     entity = Article
     label = "Redevance départementale des mines pour le minerai de lithium"
@@ -52,7 +52,7 @@ class redevance_departementale_des_mines_lithium(Variable):
 
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
-        quantite = articles("quantite_lithium_kli2O", annee_production)
+        quantite = articles("quantite_lithium_li2O_t", annee_production)
 
         tarif_rdm = parameters(period).redevances.departementales.lithium
         rdm = (quantite * tarif_rdm) * surface_communale_proportionnee

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/sel_abattage.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/sel_abattage.py
@@ -14,7 +14,7 @@ class quantite_sel_abattage_kt(Variable):
     definition_period = YEAR
 
 
-class redevance_communale_des_mines_sel_abattage_kt(Variable):
+class redevance_communale_des_mines_sel_abattage(Variable):
     value_type = float
     entity = Article
     label = "Redevance communale du sel d'abattage"
@@ -41,7 +41,7 @@ class redevance_communale_des_mines_sel_abattage_kt(Variable):
         return round(quantites * taux, decimals = 2)
 
 
-class redevance_departementale_des_mines_sel_abattage_kt(Variable):
+class redevance_departementale_des_mines_sel_abattage(Variable):
     value_type = float
     entity = Article
     label = "Redevance départementale du sel d'abattage"
@@ -68,7 +68,7 @@ class redevance_departementale_des_mines_sel_abattage_kt(Variable):
         return round(quantites * taux, decimals = 2)
 
 
-class redevance_totale_des_mines_sel_abattage_kt(Variable):
+class redevance_totale_des_mines_sel_abattage(Variable):
     value_type = float
     entity = Article
     label = "Redevance départamentale + communale des mines de sel d'abattage"
@@ -76,9 +76,9 @@ class redevance_totale_des_mines_sel_abattage_kt(Variable):
 
     def formula(articles, period) -> ndarray:
         departementale = articles(
-            "redevance_departementale_des_mines_sel_abattage_kt",
+            "redevance_departementale_des_mines_sel_abattage",
             period)
         communale = articles(
-            "redevance_communale_des_mines_sel_abattage_kt",
+            "redevance_communale_des_mines_sel_abattage",
             period)
         return departementale + communale

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/sel_dissolution.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/sel_dissolution.py
@@ -14,7 +14,7 @@ class quantite_sel_dissolution_kt(Variable):
     definition_period = YEAR
 
 
-class redevance_communale_des_mines_sel_dissolution_kt(Variable):
+class redevance_communale_des_mines_sel_dissolution(Variable):
     value_type = float
     entity = Article
     label = "Redevance communale du sel extrait en dissolution par sondage livré en dissolution"  # noqa: E501
@@ -41,7 +41,7 @@ class redevance_communale_des_mines_sel_dissolution_kt(Variable):
         return round(quantites * taux, decimals = 2)
 
 
-class redevance_departementale_des_mines_sel_dissolution_kt(Variable):
+class redevance_departementale_des_mines_sel_dissolution(Variable):
     value_type = float
     entity = Article
     label = "Redevance départementale du sel extrait en dissolution par sondage livré en dissolution"  # noqa: E501
@@ -68,7 +68,7 @@ class redevance_departementale_des_mines_sel_dissolution_kt(Variable):
         return round(quantites * taux, decimals = 2)
 
 
-class redevance_totale_des_mines_sel_dissolution_kt(Variable):
+class redevance_totale_des_mines_sel_dissolution(Variable):
     value_type = float
     entity = Article
     label = "Redevance départamentale + communale des mines du sel extrait en dissolution par sondage livré en dissolution"  # noqa: E501
@@ -76,9 +76,9 @@ class redevance_totale_des_mines_sel_dissolution_kt(Variable):
 
     def formula(articles, period) -> ndarray:
         departementale = articles(
-            "redevance_departementale_des_mines_sel_dissolution_kt",
+            "redevance_departementale_des_mines_sel_dissolution",
             period)
         communale = articles(
-            "redevance_communale_des_mines_sel_dissolution_kt",
+            "redevance_communale_des_mines_sel_dissolution",
             period)
         return departementale + communale

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/sel_raffine.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/sel_raffine.py
@@ -14,7 +14,7 @@ class quantite_sel_raffine_kt(Variable):
     definition_period = YEAR
 
 
-class redevance_communale_des_mines_sel_raffine_kt(Variable):
+class redevance_communale_des_mines_sel_raffine(Variable):
     value_type = float
     entity = Article
     label = "Redevance communale du sel raffiné"
@@ -41,7 +41,7 @@ class redevance_communale_des_mines_sel_raffine_kt(Variable):
         return round(quantites * taux, decimals = 2)
 
 
-class redevance_departementale_des_mines_sel_raffine_kt(Variable):
+class redevance_departementale_des_mines_sel_raffine(Variable):
     value_type = float
     entity = Article
     label = "Redevance départementale du sel raffiné"
@@ -68,7 +68,7 @@ class redevance_departementale_des_mines_sel_raffine_kt(Variable):
         return round(quantites * taux, decimals = 2)
 
 
-class redevance_totale_des_mines_sel_raffine_kt(Variable):
+class redevance_totale_des_mines_sel_raffine(Variable):
     value_type = float
     entity = Article
     label = "Redevance départamentale + communale des mines de sel raffiné"
@@ -76,9 +76,9 @@ class redevance_totale_des_mines_sel_raffine_kt(Variable):
 
     def formula(articles, period) -> ndarray:
         departementale = articles(
-            "redevance_departementale_des_mines_sel_raffine_kt",
+            "redevance_departementale_des_mines_sel_raffine",
             period)
         communale = articles(
-            "redevance_communale_des_mines_sel_raffine_kt",
+            "redevance_communale_des_mines_sel_raffine",
             period)
         return departementale + communale

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/zinc.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/zinc.py
@@ -6,7 +6,7 @@ from openfisca_core.variables import Variable
 from openfisca_france_fiscalite_miniere.entities import Article
 
 
-class quantite_zinc_kt(Variable):
+class quantite_zinc_100t(Variable):
     value_type = float
     entity = Article
     definition_period = YEAR
@@ -29,7 +29,7 @@ class redevance_communale_des_mines_zinc(Variable):
 
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
-        quantite = articles("quantite_zinc_kt", annee_production)
+        quantite = articles("quantite_zinc_100t", annee_production)
 
         tarif_rcm = parameters(period).redevances.communales.zinc
 
@@ -52,7 +52,7 @@ class redevance_departementale_des_mines_zinc(Variable):
 
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
-        quantite = articles("quantite_zinc_kt", annee_production)
+        quantite = articles("quantite_zinc_100t", annee_production)
 
         tarif_rdm = parameters(period).redevances.departementales.zinc
         rdm = (quantite * tarif_rdm) * surface_communale_proportionnee

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="4.1.0",
+    version="4.2.0",
     author="OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[

--- a/simulations/drfip.py
+++ b/simulations/drfip.py
@@ -126,13 +126,13 @@ def generate_matrice_drfip_guyane(data, annee_production, timestamp):
     # Redevance départementale :
     matrice["Tarifs (RDM)"] = data["tarifs_rdm"]
     matrice["Montant net (RDM)"] = data[
-        "redevance_departementale_des_mines_aurifere_kg"
+        "redevance_departementale_des_mines_aurifere"
         ]
 
     # Redevance communale :
     matrice["Tarifs (RCM)"] = data["tarifs_rcm"]
     matrice["Montant net redevance des mines (RCM)"] = data[
-        "redevance_communale_des_mines_aurifere_kg"
+        "redevance_communale_des_mines_aurifere"
         ]
 
     matrice["Total redevance des mines"] = round(
@@ -258,21 +258,21 @@ def generate_matrice_1403_drfip_guyane(data, annee_production, timestamp):
 
     matrice_1403["Redevance départementale"] = [
         data_sip_cayenne[
-            "redevance_departementale_des_mines_aurifere_kg"
+            "redevance_departementale_des_mines_aurifere"
             ].sum().astype(int),
         data_sip_kourou[
-            "redevance_departementale_des_mines_aurifere_kg"
+            "redevance_departementale_des_mines_aurifere"
             ].sum().astype(int),
         data_sip_st_laurent_du_maroni[
-            "redevance_departementale_des_mines_aurifere_kg"
+            "redevance_departementale_des_mines_aurifere"
             ].sum().astype(int)
         ]
 
     matrice_1403["Redevance communale"] = [
-        data_sip_cayenne["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
-        data_sip_kourou["redevance_communale_des_mines_aurifere_kg"].sum().astype(int),
+        data_sip_cayenne["redevance_communale_des_mines_aurifere"].sum().astype(int),
+        data_sip_kourou["redevance_communale_des_mines_aurifere"].sum().astype(int),
         data_sip_st_laurent_du_maroni[
-            "redevance_communale_des_mines_aurifere_kg"
+            "redevance_communale_des_mines_aurifere"
             ].sum().astype(int)
         ]
     matrice_1403["Taxe minière sur l'or de Guyane"] = [
@@ -353,7 +353,7 @@ def generate_matrice_1404_sip(columns_1404, data_sip, sip_name):
 
     # REDEVANCE DÉPARTEMENTALE :
     matrice_1404_sip["Produit net de la redevance (RDM)"] = data_sip[
-        "redevance_departementale_des_mines_aurifere_kg"
+        "redevance_departementale_des_mines_aurifere"
         ].values
     matrice_1404_sip[
         "Sommes revenant aux départements désignés dans la colonne 4 (a)"
@@ -362,7 +362,7 @@ def generate_matrice_1404_sip(columns_1404, data_sip, sip_name):
     # REDEVANCE COMMUNALE :
     # col. 10
     matrice_1404_sip["Produit net de la redevance (RCM)"] = data_sip[
-        "redevance_communale_des_mines_aurifere_kg"
+        "redevance_communale_des_mines_aurifere"
         ].values
     # > Répartition
     matrice_1404_sip["1ère fraction (col. 10 x 35%)"] = matrice_1404_sip[

--- a/simulations/estime_taxes_redevances.py
+++ b/simulations/estime_taxes_redevances.py
@@ -506,17 +506,17 @@ if __name__ == "__main__":
     rdm_tarif_aurifere = current_parameters.redevances.departementales.aurifere
     rcm_tarif_aurifere = current_parameters.redevances.communales.aurifere
 
-    redevance_departementale_des_mines_aurifere_kg = simulation.calculate(
-        'redevance_departementale_des_mines_aurifere_kg',
+    redevance_departementale_des_mines_aurifere = simulation.calculate(
+        'redevance_departementale_des_mines_aurifere',
         simulation_period
         )
-    redevance_communale_des_mines_aurifere_kg = simulation.calculate(
-        'redevance_communale_des_mines_aurifere_kg',
+    redevance_communale_des_mines_aurifere = simulation.calculate(
+        'redevance_communale_des_mines_aurifere',
         simulation_period
         )
 
-    logging.debug("🍏    redevance_departementale_des_mines_aurifere_kg")
-    logging.debug(redevance_departementale_des_mines_aurifere_kg)
+    logging.debug("🍏    redevance_departementale_des_mines_aurifere")
+    logging.debug(redevance_departementale_des_mines_aurifere)
 
     taxe_tarif_pme = current_parameters.taxes.guyane.categories.pme
     taxe_tarif_autres_entreprises = current_parameters.taxes.guyane.categories.autre
@@ -536,10 +536,10 @@ if __name__ == "__main__":
         'surface_communale', 'surface_totale'
         # Redevance départementale :
         'tarifs_rdm',
-        'redevance_departementale_des_mines_aurifere_kg',
+        'redevance_departementale_des_mines_aurifere',
         # Redevance communale :
         'tarifs_rcm',
-        'redevance_communale_des_mines_aurifere_kg',
+        'redevance_communale_des_mines_aurifere',
         # Taxe minière sur l'or de Guyane :
         'taxe_tarif_pme',
         'taxe_tarif_autres',
@@ -572,22 +572,22 @@ if __name__ == "__main__":
 
     # Redevance départementale :
     resultat['tarifs_rdm'] = numpy.where(
-        redevance_departementale_des_mines_aurifere_kg > 0,
+        redevance_departementale_des_mines_aurifere > 0,
         rdm_tarif_aurifere,
         ""
         )
     resultat[
-        'redevance_departementale_des_mines_aurifere_kg'
-        ] = redevance_departementale_des_mines_aurifere_kg
+        'redevance_departementale_des_mines_aurifere'
+        ] = redevance_departementale_des_mines_aurifere
     # Redevance communale :
     resultat['tarifs_rcm'] = numpy.where(
-        redevance_communale_des_mines_aurifere_kg > 0,
+        redevance_communale_des_mines_aurifere > 0,
         rcm_tarif_aurifere,
         ""
         )
     resultat[
-        'redevance_communale_des_mines_aurifere_kg'
-        ] = redevance_communale_des_mines_aurifere_kg
+        'redevance_communale_des_mines_aurifere'
+        ] = redevance_communale_des_mines_aurifere
     # Taxe minière sur l'or de Guyane :
     resultat['taxe_tarif_pme'] = numpy.where(
         data['categorie_entreprise'] == "PME", taxe_tarif_pme, None)

--- a/simulations/reformes/test_essai_selg.py
+++ b/simulations/reformes/test_essai_selg.py
@@ -111,11 +111,11 @@ simulation.set_input(
     activite_selg_2018_par_titre['renseignements_selg']
     )
 
-redevance_communale_des_mines_sel_abattage_kt = simulation.calculate(
-    'redevance_communale_des_mines_sel_abattage_kt', period
+redevance_communale_des_mines_sel_abattage = simulation.calculate(
+    'redevance_communale_des_mines_sel_abattage', period
     )
-print("redevance_communale_des_mines_sel_abattage_kt ?")  # noqa: T201
-print(redevance_communale_des_mines_sel_abattage_kt)  # noqa: T201
+print("redevance_communale_des_mines_sel_abattage ?")  # noqa: T201
+print(redevance_communale_des_mines_sel_abattage)  # noqa: T201
 
 
 # SIMULATION : ESSAI REFORME
@@ -145,7 +145,7 @@ for index, row in activite_selg_2018_par_titre.iterrows():
     titre_surface_totale = sum(map(float, titre_communes.values()))
     print(titre_surface_totale, " = ", titre_communes)  # noqa: T201
 
-    redevance_actuelle = redevance_communale_des_mines_sel_abattage_kt[index]
+    redevance_actuelle = redevance_communale_des_mines_sel_abattage[index]
     print("/titre", redevance_actuelle, "€")  # noqa: T201
 
     for commune in titre_communes:

--- a/simulations/reformes/test_essai_selh.py
+++ b/simulations/reformes/test_essai_selh.py
@@ -111,11 +111,11 @@ simulation.set_input(
     activite_selh_2018_par_titre['renseignements_selh']
     )
 
-redevance_communale_des_mines_sel_dissolution_kt = simulation.calculate(
-    'redevance_communale_des_mines_sel_dissolution_kt', period
+redevance_communale_des_mines_sel_dissolution = simulation.calculate(
+    'redevance_communale_des_mines_sel_dissolution', period
     )
-print("redevance_communale_des_mines_sel_dissolution_kt ?")  # noqa: T201
-print(redevance_communale_des_mines_sel_dissolution_kt)  # noqa: T201
+print("redevance_communale_des_mines_sel_dissolution ?")  # noqa: T201
+print(redevance_communale_des_mines_sel_dissolution)  # noqa: T201
 
 
 # SIMULATION : ESSAI REFORME
@@ -146,7 +146,7 @@ for index, row in activite_selh_2018_par_titre.iterrows():
     titre_surface_totale = sum(map(float, titre_communes.values()))
     print(titre_surface_totale, " = ", titre_communes)  # noqa: T201
 
-    redevance_actuelle = redevance_communale_des_mines_sel_dissolution_kt[index]
+    redevance_actuelle = redevance_communale_des_mines_sel_dissolution[index]
     print("/titre", redevance_actuelle, "€")  # noqa: T201
 
     for commune in titre_communes:


### PR DESCRIPTION
On a vu que certaines substances ne "respectaient" pas la nomenclature `quantite_${substance}_${unite}` ou n'avaient pas la bonne unité.

Nos unités : https://github.com/MTES-MCT/camino/blob/master/packages/common/src/static/unites.ts#L39