### PR TITLE
Ajoute la taxe Guyane pour 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
 
+# 4.1.0 [#30](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/30)
+
+* Évolution du système socio-fiscal.
+* Zones impactées :
+  - `parameters/taxes/guyane/categories/*`
+* Détails :
+  - Revalorise les tarifs 2022 de la taxe sur l'or en Guyane.
+
+
 # 4.0.0 [#27](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/27)
 
 * Évolution du système socio-fiscal **non rétrocompatible**.
 * Périodes concernées : à partir du 01/01/2020.
-* Zones impactées : 
+* Zones impactées :
   - `variables/redevances.py`
   - `variables/taxes.py`
 * Détails :
@@ -36,7 +45,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
   - `entities.py`.
   - `variables/*`
 * Détails :
@@ -48,7 +57,7 @@
 
 * Changement mineur.
 * Périodes concernées : à partir du 01/01/2020.
-* Zones impactées : 
+* Zones impactées :
   - `simulations/drfip.py`
   - `simulations/estime_taxes_redevances.py`
 * Détails :
@@ -59,7 +68,7 @@
 
 * Changement mineur.
 * Périodes concernées : à partir du 01/01/2020.
-* Zones impactées : 
+* Zones impactées :
   - `simulations/drfip.py`
   - `simulations/estime_taxes_redevances.py`
 * Détails :
@@ -71,7 +80,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2014.
-* Zones impactées : 
+* Zones impactées :
   - `parameters/taxes/guyane/categories/*`
   - `parameters/fiscalite/frais/*`
   - `variables/fiscalite.py` désormais `variables/frais.py`
@@ -85,7 +94,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2021.
-* Zones impactées : 
+* Zones impactées :
   - `parameters/redevances/departementales/*`
   - `parameters/redevances/communales/*`
 * Détails :

--- a/openfisca_france_fiscalite_miniere/parameters/taxes/guyane/categories/autre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/taxes/guyane/categories/autre.yaml
@@ -24,3 +24,7 @@ values:
     value: 996.13
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044329274/2021-11-17
+  2022-01-01:
+    value: 977.95
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044329274/2022-07-27/

--- a/openfisca_france_fiscalite_miniere/parameters/taxes/guyane/categories/pme.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/taxes/guyane/categories/pme.yaml
@@ -24,3 +24,7 @@ values:
     value: 498.06
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044329274/2021-11-17
+  2022-01-01:
+    value: 488.97
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044329274/2022-07-27/

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="4.0.0",
+    version="4.1.0",
     author="OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Zones impactées :
  - `parameters/taxes/guyane/categories/*`
* Détails :
  - Revalorise les tarifs 2022 de la taxe sur l'or en Guyane.

- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.
- - - -
