### PR TITLE
Ajoute les redevances départementales et communales pour 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-# 4.3.0 [#31](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/31)
+### 4.3.0 [#31](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/31)
 
 * Ajoute les redevances départementales et communales pour l'année 2022
 * Zones impactées :
   - `parameters/redevances/*`
+* Détails :
+  - Met à jour la version mineure d'OpenFisca (35.9.0)
 
-# 4.2.0 [#29](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/29)
+### 4.2.0 [#29](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/29)
 
 * Uniformisation des noms des variables des redevances communales et departementales
 * Zones impactées :
@@ -17,7 +19,7 @@
   - Enlève l'unité dans le nom de la classe
     - par exemple : `redevance_communale_des_mines_sel_raffine_kt` devient `redevance_communale_des_mines_sel_raffine`
 
-# 4.1.0 [#30](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/30)
+### 4.1.0 [#30](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/30)
 
 * Évolution du système socio-fiscal.
 * Zones impactées :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 4.3.0 [#31](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/31)
+
+* Ajoute les redevances départementales et communales pour l'année 2022
+* Zones impactées :
+  - `parameters/redevances/*`
+
 # 4.2.0 [#29](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/29)
 
 * Uniformisation des noms des variables des redevances communales et departementales

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/antimoine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/antimoine.yaml
@@ -23,3 +23,7 @@ values:
     value: 13.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 13.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/argentifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/argentifere.yaml
@@ -23,3 +23,7 @@ values:
     value: 270.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 285.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/arsenic.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/arsenic.yaml
@@ -23,3 +23,7 @@ values:
     value: 731.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 771.90
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/aurifere.yaml
@@ -24,3 +24,7 @@ values:
     value: 166.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 175.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bauxite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bauxite.yaml
@@ -23,3 +23,7 @@ values:
     value: 636.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 671.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bismuth.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bismuth.yaml
@@ -23,3 +23,7 @@ values:
     value: 64.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 67.60
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bitume_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bitume_distillation.yaml
@@ -24,3 +24,7 @@ values:
     value: 54.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 57.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bitume_non_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/bitume_non_distillation.yaml
@@ -24,3 +24,7 @@ values:
     value: 1635.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 1725.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/butane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/butane.yaml
@@ -23,3 +23,7 @@ values:
     value: 9.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 9.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/charbon.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/charbon.yaml
@@ -23,3 +23,7 @@ values:
     value: 254.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 268.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/cuivre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/cuivre.yaml
@@ -23,3 +23,7 @@ values:
     value: 21.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 22.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/degazolinage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/degazolinage.yaml
@@ -23,3 +23,7 @@ values:
     value: 8.60
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 9.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/etain.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/etain.yaml
@@ -23,3 +23,7 @@ values:
     value: 132.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 139.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/fer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/fer.yaml
@@ -23,3 +23,7 @@ values:
     value: 375.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 396.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/fer_pyrite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/fer_pyrite.yaml
@@ -23,3 +23,7 @@ values:
     value: 545.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 575.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/fluorine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/fluorine.yaml
@@ -23,3 +23,7 @@ values:
     value: 827.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 872.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_carbonique.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_carbonique.yaml
@@ -23,3 +23,7 @@ values:
     value: 356.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 375.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel.yaml
@@ -23,3 +23,7 @@ values:
     value: 351.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 370.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/gaz_naturel_mer.yaml
@@ -6,15 +6,10 @@ values:
   2017-01-01:
     value: 25.3
     metadata:
-      reference: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2018-01-01
-  2018-01-01:
-    value: 25.3
-    metadata:
-      reference: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2019-01-01
-  2019-01-01:
-    value: 25.3
-    metadata:
       reference: 
+        2017-01-01: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2018-01-01
+        2018-01-01: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2019-01-01
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-01-01
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-07-25
         2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12
+        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/lignites_ge_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/lignites_ge_13.yaml
@@ -23,3 +23,7 @@ values:
     value: 972.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 1026.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/lignites_lt_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/lignites_lt_13.yaml
@@ -23,3 +23,7 @@ values:
     value: 236.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 249.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/lithium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/lithium.yaml
@@ -23,3 +23,7 @@ values:
     value: 54.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 57.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/manganese.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/manganese.yaml
@@ -23,3 +23,7 @@ values:
     value: 406.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 428.60
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/molybdene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/molybdene.yaml
@@ -23,3 +23,7 @@ values:
     value: 270.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 285.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut.yaml
@@ -23,3 +23,7 @@ values:
     value: 1221.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 1288.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/petrole_brut_mer.yaml
@@ -18,3 +18,4 @@ values:
         2019-01-01: https://beta.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-01-01
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006191913/2020-07-25
         2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12
+        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/plomb.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/plomb.yaml
@@ -23,3 +23,7 @@ values:
     value: 686.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 724.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/potassium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/potassium.yaml
@@ -23,3 +23,7 @@ values:
     value: 286.60
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 302.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/propane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/propane.yaml
@@ -23,3 +23,7 @@ values:
     value: 9.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 9.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/sel_abattage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/sel_abattage.yaml
@@ -23,3 +23,7 @@ values:
     value: 786.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 830.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/sel_dissolution.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/sel_dissolution.yaml
@@ -23,3 +23,7 @@ values:
     value: 159.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 168.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/sel_raffine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/sel_raffine.yaml
@@ -23,3 +23,7 @@ values:
     value: 478.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 505.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/soufre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/soufre.yaml
@@ -23,3 +23,7 @@ values:
     value: 3.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 3.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/tungstene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/tungstene.yaml
@@ -23,3 +23,7 @@ values:
     value: 148.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 156.90
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/uranium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/uranium.yaml
@@ -23,3 +23,7 @@ values:
     value: 323.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 341.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/communales/zinc.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/communales/zinc.yaml
@@ -23,3 +23,7 @@ values:
     value: 545.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663105/2021-06-12/
+  2022-01-01:
+    value: 575.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/antimoine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/antimoine.yaml
@@ -24,3 +24,7 @@ values:
     value: 3.0
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 3.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/antimoine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/antimoine.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 3.20
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/argentifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/argentifere.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 56.80
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/argentifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/argentifere.yaml
@@ -24,3 +24,7 @@ values:
     value: 53.80
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 56.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/arsenic.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/arsenic.yaml
@@ -24,3 +24,7 @@ values:
     value: 148.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 156.90
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/arsenic.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/arsenic.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 156.90
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 35.0
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/aurifere.yaml
@@ -24,3 +24,7 @@ values:
     value: 33.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 35.0
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bauxite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bauxite.yaml
@@ -24,3 +24,7 @@ values:
     value: 127.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 134.10
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bauxite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bauxite.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 134.10
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bismuth.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bismuth.yaml
@@ -24,3 +24,7 @@ values:
     value: 13.0
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 13.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bismuth.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bismuth.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 13.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_distillation.yaml
@@ -25,3 +25,7 @@ values:
     value: 11.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 11.90
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_distillation.yaml
@@ -28,4 +28,4 @@ values:
   2022-01-01:
     value: 11.90
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_non_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_non_distillation.yaml
@@ -25,3 +25,7 @@ values:
     value: 325.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 343.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_non_distillation.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/bitume_non_distillation.yaml
@@ -28,4 +28,4 @@ values:
   2022-01-01:
     value: 343.30
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/butane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/butane.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 7.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/butane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/butane.yaml
@@ -24,3 +24,7 @@ values:
     value: 7.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 7.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/charbon.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/charbon.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 130.20
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/charbon.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/charbon.yaml
@@ -24,3 +24,7 @@ values:
     value: 123.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 130.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/cuivre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/cuivre.yaml
@@ -24,3 +24,7 @@ values:
     value: 4.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 4.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/cuivre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/cuivre.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 4.50
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/degazolinage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/degazolinage.yaml
@@ -24,3 +24,7 @@ values:
     value: 6.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 6.90
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/degazolinage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/degazolinage.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 6.90
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/etain.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/etain.yaml
@@ -24,3 +24,7 @@ values:
     value: 26.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 27.60
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/etain.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/etain.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 27.60
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer.yaml
@@ -24,3 +24,7 @@ values:
     value: 78.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 82.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 82.40
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer_pyrite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer_pyrite.yaml
@@ -24,3 +24,7 @@ values:
     value: 111.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 117.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer_pyrite.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fer_pyrite.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 117.50
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fluorine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fluorine.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 177.30
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fluorine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/fluorine.yaml
@@ -24,3 +24,7 @@ values:
     value: 168.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 177.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_carbonique.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_carbonique.yaml
@@ -24,3 +24,7 @@ values:
     value: 72.80
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 76.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_carbonique.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_carbonique.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 76.80
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 541.20
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel.yaml
@@ -24,3 +24,7 @@ values:
     value: 513.0
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 541.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel_mer.yaml
@@ -13,3 +13,4 @@ values:
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
         2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/gaz_naturel_mer.yaml
@@ -13,4 +13,4 @@ values:
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
         2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
-        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_ge_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_ge_13.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 203.20
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_ge_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_ge_13.yaml
@@ -24,3 +24,7 @@ values:
     value: 192.60
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 203.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_lt_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_lt_13.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 55.30
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_lt_13.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lignites_lt_13.yaml
@@ -24,3 +24,7 @@ values:
     value: 52.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 55.30
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lithium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lithium.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 11.80
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lithium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/lithium.yaml
@@ -24,3 +24,7 @@ values:
     value: 11.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 11.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/manganese.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/manganese.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 86.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/manganese.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/manganese.yaml
@@ -24,3 +24,7 @@ values:
     value: 82.20
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 86.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/molybdene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/molybdene.yaml
@@ -24,3 +24,7 @@ values:
     value: 54.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 57.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/molybdene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/molybdene.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 57.50
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut.yaml
@@ -22,3 +22,7 @@ values:
     value: 1569.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 1655.40
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut.yaml
@@ -25,4 +25,4 @@ values:
   2022-01-01:
     value: 1655.40
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut_mer.yaml
@@ -13,3 +13,4 @@ values:
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
         2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut_mer.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/petrole_brut_mer.yaml
@@ -13,4 +13,4 @@ values:
         2019-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038686694/2019-06-08/
         2020-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042159975/2020-07-25/
         2021-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
-        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+        2022-01-01: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/plomb.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/plomb.yaml
@@ -24,3 +24,7 @@ values:
     value: 132.50
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 139.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/plomb.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/plomb.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 139.80
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/potassium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/potassium.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 60.20
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/potassium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/potassium.yaml
@@ -24,3 +24,7 @@ values:
     value: 57.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 60.20
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/propane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/propane.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 7.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/propane.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/propane.yaml
@@ -24,3 +24,7 @@ values:
     value: 7.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 7.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_abattage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_abattage.yaml
@@ -24,3 +24,7 @@ values:
     value: 159.90
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 168.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_abattage.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_abattage.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 168.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_dissolution.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_dissolution.yaml
@@ -24,3 +24,7 @@ values:
     value: 31.0
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 32.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_dissolution.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_dissolution.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 32.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_raffine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_raffine.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 99.60
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_raffine.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/sel_raffine.yaml
@@ -24,3 +24,7 @@ values:
     value: 94.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 99.60
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/soufre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/soufre.yaml
@@ -25,4 +25,4 @@ values:
   2022-01-01:
     value: 1.80
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/soufre.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/soufre.yaml
@@ -22,3 +22,7 @@ values:
     value: 1.70
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 1.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/tungstene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/tungstene.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 30.70
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/tungstene.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/tungstene.yaml
@@ -24,3 +24,7 @@ values:
     value: 29.10
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 30.70
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/uranium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/uranium.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 67.80
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/uranium.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/uranium.yaml
@@ -24,3 +24,7 @@ values:
     value: 64.30
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 67.80
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/zinc.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/zinc.yaml
@@ -24,3 +24,7 @@ values:
     value: 111.40
     metadata:
       reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043663002/2021-06-12/
+  2022-01-01:
+    value: 117.50
+    metadata:
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/zinc.yaml
+++ b/openfisca_france_fiscalite_miniere/parameters/redevances/departementales/zinc.yaml
@@ -27,4 +27,4 @@ values:
   2022-01-01:
     value: 117.50
     metadata:
-      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045765025/2022-05-07/
+      reference: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000045764991/2022-05-07/

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
@@ -355,10 +355,10 @@
   output:
     redevance_communale_des_mines_antimoine:
       2021: 0
-      2022: 13.10 * 100 * (1/2)
+      2022: 13.80 * 100 * (1/2)
     redevance_departementale_des_mines_antimoine:
       2021: 0
-      2022: 3 * 100 * (1/2)
+      2022: 3.20 * 100 * (1/2)
 
 # - name: "Minerais de plomb (par centaine de tonnes de plomb contenu)"
 #   input:

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
@@ -346,7 +346,21 @@
       2020: 72.10 * 100 * 1
 
 
-- name: "Minerais d'antimoine (par tonne d'antimoine contenu)"
+- name: "Minerais d'antimoine (par tonne d'antimoine contenu) 2020"
+  period: 2020  # année de production
+  input:
+    quantite_antimoine_t: 100
+    surface_communale: 1
+    surface_totale: 2
+  output:
+    redevance_communale_des_mines_antimoine:
+      2020: 0
+      2021: 13.10 * 100 * (1/2)
+    redevance_departementale_des_mines_antimoine:
+      2020: 0
+      2021: 3 * 100 * (1/2)
+
+- name: "Minerais d'antimoine (par tonne d'antimoine contenu) 2021"
   period: 2021  # année de production
   input:
     quantite_antimoine_t: 100

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="4.2.0",
+    version="4.3.0",
     author="OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[
@@ -25,7 +25,7 @@ setup(
             ),
         ],
     install_requires = [
-        "OpenFisca-Core[web-api] >= 35.0.0, < 36.0.0",
+        "OpenFisca-Core[web-api] >= 35.9.0, < 36.0.0",
         ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/01/2022.
* Zones impactées : `parameters/redevances/*`.
* Détails :
  - Ajout des redevances départementales et communales pour l'année 2022

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -
