### PR TITLE
fix(lithium): modification du nom lithium li20 en lithium + upgrade openfisca-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 5.0.0 [#34](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/34)
+* Change lithium_li20 par lithium pour garder une cohérence entre les paramètres et les variables
+* Met à jour OpenFiscaCore et web en version 37.0.0
+* Zones impactées :
+  - `variables/redevances_communales_departementales/lithium.py`
+
 ### 4.3.1 [#32](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pull/32)
 * Vérifie le formatage des fichiers python et yaml
 * Zones impactées : '*.py && *.yml'

--- a/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
+++ b/openfisca_france_fiscalite_miniere/tests/test_redevances.yaml
@@ -508,10 +508,10 @@
 #       2018: 100
 #       2017: 100
 #   output:
-#     redevance_communale_des_mines_lithium_li20:
+#     redevance_communale_des_mines_lithium:
 #       2019: 4900
 #       2018: 4760
-#     redevance_departementale_des_mines_lithium_li20:
+#     redevance_departementale_des_mines_lithium:
 #       2019: 1000
 #       2018: 970
 #     redevance_totale_des_mines_lithium:

--- a/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/lithium.py
+++ b/openfisca_france_fiscalite_miniere/variables/redevances_communales_departementales/lithium.py
@@ -6,7 +6,7 @@ from openfisca_core.variables import Variable
 from openfisca_france_fiscalite_miniere.entities import Article
 
 
-class quantite_lithium_li2O_t(Variable):
+class quantite_lithium_t(Variable):
     value_type = float
     entity = Article
     definition_period = YEAR
@@ -14,7 +14,7 @@ class quantite_lithium_li2O_t(Variable):
     reference = "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006294877/2020-03-25"  # noqa: E501
 
 
-class redevance_communale_des_mines_lithium_li20(Variable):
+class redevance_communale_des_mines_lithium(Variable):
     value_type = float
     entity = Article
     definition_period = YEAR
@@ -29,7 +29,7 @@ class redevance_communale_des_mines_lithium_li20(Variable):
 
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
-        quantite = articles("quantite_lithium_li2O_t", annee_production)
+        quantite = articles("quantite_lithium_t", annee_production)
 
         tarif_rcm = parameters(period).redevances.communales.lithium
 
@@ -37,7 +37,7 @@ class redevance_communale_des_mines_lithium_li20(Variable):
         return round(rcm, decimals = 2)
 
 
-class redevance_departementale_des_mines_lithium_li20(Variable):
+class redevance_departementale_des_mines_lithium(Variable):
     value_type = float
     entity = Article
     label = "Redevance départementale des mines pour le minerai de lithium"
@@ -52,7 +52,7 @@ class redevance_departementale_des_mines_lithium_li20(Variable):
 
         surface_communale_proportionnee = articles(
             "surface_communale_proportionnee", annee_production)
-        quantite = articles("quantite_lithium_li2O_t", annee_production)
+        quantite = articles("quantite_lithium_t", annee_production)
 
         tarif_rdm = parameters(period).redevances.departementales.lithium
         rdm = (quantite * tarif_rdm) * surface_communale_proportionnee

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-France-Fiscalite-Miniere",
-    version="4.3.1",
+    version="5.0.0",
     author="OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[
@@ -25,7 +25,7 @@ setup(
             ),
         ],
     install_requires = [
-        "OpenFisca-Core[web-api] >= 35.9.0, < 36.0.0",
+        "OpenFisca-Core[web-api] >= 37.0.0, < 38.0.0",
         ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
* Change lithium_li20 par lithium pour garder une cohérence entre les paramètres et les variables
* Met à jour OpenFiscaCore et web en version 37.0.0
* Zones impactées :
  - `variables/redevances_communales_departementales/lithium.py`

Ces changements :

- Modifient l'API publique d'OpenFisca France — Fiscalité Minière.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france-fiscalite-miniere/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france-fiscalite-miniere/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus


